### PR TITLE
Exclude 'ja' from mozilla.org stats, expose view's name

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,5 +73,10 @@ switch ($case) {
         break;
 }
 
+if (isset($view)) {
+    // Extract the view name removing path ($views) and extension ('.inc.php')
+    $viewname = substr($view, strlen($views), -8);
+}
+
 ob_start();
 include $template;

--- a/templates/template.inc.php
+++ b/templates/template.inc.php
@@ -193,7 +193,10 @@ table.globallist {
 </head>
 
 <body>
-<?php include $view; ?>
+<?php
+    echo "<!-- Current view: $viewname -->\n";
+    include $view;
+?>
 
 </body>
 </html>

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -97,6 +97,12 @@ foreach ($sites[$website][4] as $_file) {
         unset($GLOBALS[$_lang]);
     }
 
+    // ja+mozilla.org is not relevant, remove "ja" from $adu and $done in that case
+    if ($website == 0) {
+        unset($adu['ja']);
+        unset($done['ja']);
+    }
+
     // adu count
     $done = array_flip($done);
     $done = array_intersect_key($adu, $done);
@@ -109,7 +115,12 @@ foreach ($sites[$website][4] as $_file) {
          . round($count_done/count($targetted_locales)*100)
          . '%)<br>'
          .  $done
-         . ' of our l10n user base</td></tr>';
+         . ' of our l10n user base';
+
+    if ($website == 0) {
+        echo ' (excluding ja)';
+    }
+    echo    '</td></tr>';
     echo '</table>';
 
 


### PR DESCRIPTION
1) Expose as a comment the view's name, so I don't need to check index.php every time ;-)

2) Exclude 'ja' from $done and $adu to get a more realistic ADU coverage (and add a warning to the footer)

This should fix #9
