### PR TITLE
View: display complete files not activated

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,27 +8,30 @@ if ($locale == '' && $action == '') {
     /* case 1: no locale is requested, we display links to all locales */
     $case = 1;
 } elseif ($locale == '' && $action == 'errors') {
-    /* case 2: no locale is requested, we display links to all locales */
+    /* case 2: no locale is requested, we display errors for all locales */
     $case = 2;
-} elseif ($locale != '' && $website == '' && $serial == false) {
-    /* case 3: we have a locale but no website is defined, we display the status page for the locale */
+} elseif ($locale == '' && $action == 'activation') {
+    /* case 3: no locale is requested, we display a list of pages completely translated but not activated */
     $case = 3;
-} elseif ($website != '' && array_key_exists($website, $sites) && $serial == false && $action == '') {
-    /* case 4: we have a website defined and just want to see the global status for lang files on this website */
+} elseif ($locale != '' && $website == '' && $serial == false) {
+    /* case 4: we have a locale but no website is defined, we display the status page for the locale */
     $case = 4;
-} elseif ($locale != '' && $website == '' && $serial == true) {
-    /* case 5: data fetched externally */
+} elseif ($website != '' && array_key_exists($website, $sites) && $serial == false && $action == '') {
+    /* case 5: we have a website defined and just want to see the global status for lang files on this website */
     $case = 5;
-} elseif ($locale == ''  && $serial == false && $action == 'count') {
-    /* case 6: list all locales and give the number of untranslated strings for all of them */
+} elseif ($locale != '' && $website == '' && $serial == true) {
+    /* case 6: data fetched externally */
     $case = 6;
-} elseif ($locale == ''  && $serial == false && $action == 'translate') {
-    /* case 7: list all translations of a string for snippets */
+} elseif ($locale == ''  && $serial == false && $action == 'count') {
+    /* case 7: list all locales and give the number of untranslated strings for all of them */
     $case = 7;
+} elseif ($locale == ''  && $serial == false && $action == 'translate') {
+    /* case 8: list all translations of a string for snippets */
+    $case = 8;
 }
 
 if ($action == 'api') {
-    $case = 8;
+    $case = 9;
 }
 
 switch ($case) {
@@ -42,9 +45,13 @@ switch ($case) {
         break;
     case 3:
         $template = $templates . 'template.inc.php';
-        $view     = $views . 'listsitesforlocale.inc.php';
+        $view     = $views . 'activation.inc.php';
         break;
     case 4:
+        $template = $templates . 'template.inc.php';
+        $view     = $views . 'listsitesforlocale.inc.php';
+        break;
+    case 5:
         if (!isset($_GET['json'])) {
             $template = $templates . 'template.inc.php';
             $view     = $views . 'globalstatus.inc.php';
@@ -52,19 +59,19 @@ switch ($case) {
             $template= $views . 'globalstatus.inc.php';
         }
         break;
-    case 5:
+    case 6:
         // export mode for webdashboard
         $template = $views . 'export.inc.php';
         break;
-    case 6:
+    case 7:
         $template = $templates . 'template.inc.php';
         $view     = $views . 'countstrings.inc.php';
         break;
-    case 7:
+    case 8:
         $template = $templates . 'template.inc.php';
         $view     = $views . 'translatestrings.inc.php';
         break;
-    case 8:
+    case 9:
         $template = $views . 'json.inc.php';
         break;
     default:

--- a/views/activation.inc.php
+++ b/views/activation.inc.php
@@ -1,0 +1,66 @@
+<p id="back"><a href="http://l10n.mozilla-community.org/webdashboard/">Back to Web Dashboard</a></p>
+
+<h1>Complete files not activated</h1>
+
+<?php
+
+echo '<table class="sortable globallist">';
+echo '<thead>';
+echo '<tr>
+        <th>Locale</th>
+        <th>Filename</th>
+        <th>Identical</th>
+        <th>Translated</th>
+        <th>Missing</th>
+        <th>Obsolete</th>
+        <th>Activated</th>
+      </tr>';
+echo '</thead>';
+
+// We only consider mozilla.org for this view, so $sites[0]
+$site = $sites[0];
+$key = 0;
+
+foreach ($site[4] as $filename) {
+    $reflang = $site[5];
+    if (!in_array($filename, $no_active_tag)) {
+        // I need to check only files that can be activated
+
+        // Find target locales for this filename
+        $target_locales = (is_array($langfiles_subsets[$site[0]][$filename]))
+                          ? $langfiles_subsets[$site[0]][$filename]
+                          : $site[3];
+
+        getEnglishSource($reflang, $key, $filename);
+
+        foreach ($target_locales as $locale) {
+            if ($locale == 'en' || $locale == 'en-GB') {
+                continue;
+            }
+
+            // If the .lang file does not exist, just skip the locale for this file
+            $local_lang_file = $site[1] . $site[2] . $locale . '/' . $filename;
+            if (!file_exists($local_lang_file)) {
+                continue;
+            }
+
+            analyseLangFile($locale, $key, $filename);
+            $todo = count($GLOBALS[$locale]['Identical']) + count($GLOBALS[$locale]['Missing']);
+            $activation_status = ($GLOBALS[$locale]['activated']) ? 'yes' : 'no';
+
+            if (($todo==0) && ($activation_status=='no')) {
+                echo '<tr>';
+                echo '  <td>' . $locale . '</td>';
+                echo '  <td>' . $filename . '</td>';
+                echo '  <td>' . count($GLOBALS[$locale]['Identical']) . '</td>';
+                echo '  <td>' . count($GLOBALS[$locale]['Translated']) . '</td>';
+                echo '  <td>' . count($GLOBALS[$locale]['Missing']) . '</td>';
+                echo '  <td>' . count($GLOBALS[$locale]['Obsolete']) . '</td>';
+                echo '  <td>' . $activation_status . '</td>';
+                echo '</tr>';
+            }
+            unset($GLOBALS[$locale]);
+        }
+        unset($GLOBALS['__english_moz']);
+    }
+}


### PR DESCRIPTION
This should fix issue #24. Based on the results, I guess we also need to update $no_active_tag.

These are the files reported as non active: fx36start.lang, survey1.lang, survey2.lang, survey3.lang, survey4.lang, julyevent.lang, fhr.lang, marketplacebadge.lang
