### PR TITLE
Remove "tr" from Pootle import

### DIFF
--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -17,7 +17,7 @@ require __DIR__ . '/settings.inc.php';
 include __DIR__ . '/adu.inc.php';
 
 $locamotion_locales = ['ach', 'af', 'cy', 'en-ZA', 'ff', 'gd', 'hi-IN', 'kk',
-'km', 'ku', 'ms', 'my', 'oc', 'son', 'tr', 'ur', 'vi', 'xh'];
+                       'km', 'ku', 'ms', 'my', 'oc', 'son', 'ur', 'vi', 'xh'];
 
 $mozillaorg_lang = [
     'download.lang'                           => true,


### PR DESCRIPTION
Selim is working directly on SVN, Pootle only has a very partial and old status of the files.
