### PR TITLE
Fix sources to remove errors and activation

### DIFF
--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -84,6 +84,7 @@ $no_active_tag = [
     'snippets.lang',
     'upgradepromos.lang',
     'mwc2014_promos.lang',
+    'firefox/includes/mwc_2014_schedule.lang',
 ];
 
 $firefoxhealthreport_lang = ['fhr.lang' => true];
@@ -97,9 +98,8 @@ $snippets_lang = [
     'jan2014.lang' => true,
 ];
 
-$slogans_locales = ['bg', 'ca', 'cs', 'de', 'el', 'es-AR', 'el', 'es-CL',
-'es-ES', 'es-MX', 'fr', 'hu', 'hr', 'it', 'ja', 'ko',  'pl', 'pt-BR',
-'ro', 'sr', 'sr-Latn', 'zh-CN', 'zh-TW'];
+$slogans_locales = ['bg', 'ca', 'cs', 'de', 'el', 'el', 'es-ES', 'fr', 'hu', 'hr', 'it',
+                    'ja', 'ko',  'pl', 'pt-BR', 'ro', 'sr', 'sr-Latn', 'zh-CN', 'zh-TW'];
 
 $marketplacebadge_locales = ['bg', 'bn-BD', 'ca', 'cs', 'de', 'el', 'es-ES', 'hr', 'hu', 'it',
                              'nl', 'pl', 'pt-BR', 'ro', 'ru', 'sk', 'sr', 'sr-Latn', 'tr'];


### PR DESCRIPTION
Add "firefox/includes/mwc_2014_schedule.lang" to files without active status (activation view).

Remove es-AR, es-CL, and es-MX from slogans: as it is, we generate a warning for missing file on every loop and display the file in their dashboard. We can either remove locales or copy over the files in granary, I think the first option is cleaner and easier to maintain than having multiple files around with the same content.
