### PR TITLE
Create a wider range of status for lang files - fix issue #7

### DIFF
--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -24,61 +24,170 @@ $locamotion_locales = ['ach', 'af', 'cy', 'dsb', 'en-ZA', 'es-MX', 'ff', 'gd', '
     kk (20130427)
 */
 
-$mozillaorg_lang = [
-    'download.lang'                           => true,
-    'download_button.lang'                    => true,
-    'esr.lang'                                => false,
-    'euballot.lang'                           => false,
-    'firefox/geolocation.lang'                => false,
-    'firefox/new.lang'                        => true,
-    'firefox/channel.lang'                    => true,
-    'firefox/speed.lang'                      => false,
-    'firefox/os/index.lang'                   => true,
-    'firefox/os/faq.lang'                     => false,
-    'firefox/partners/index.lang'             => true,
-    'firefox/includes/mwc_2014_schedule.lang' => true,
-    'firefox/desktop/index.lang'              => true,
-    'firefox/desktop/customize.lang'          => true,
-    'firefox/desktop/fast.lang'               => true,
-    'firefox/desktop/trust.lang'              => true,
-    'firefox/desktop/tips.lang'               => true,
-    'firefox/sync.lang'                       => true,
-    'mwc2014_promos.lang'                     => true,
-    'firefox/whatsnew.lang'                   => true,
-//    'firefox/windows-8-touch.lang'            => false,
-    'firefox/installer-help.lang'             => true,
-    'firefox/australis/firefox_tour.lang'     => true,
-    'firefoxflicks.lang'                      => false,
-    'firefoxlive.lang'                        => false,
-    'firefoxos/firefoxos.lang'                => true,
-    'firefoxtesting.lang'                     => true,
-    'foundation/annualreport/2011.lang'       => false,
-    'foundation/annualreport/2011faq.lang'    => true,
-    'foundation/annualreport/2012/index.lang' => true,
-    'foundation/annualreport/2012/faq.lang'   => false,
-    'foundationsection.lang'                  => false,
-    'lightbeam/lightbeam.lang'                => false,
-    'main.lang'                               => true,
-    'marketplace/marketplace.lang'            => true,
-    'marketplace/partners.lang'               => false,
-    'mobile.lang'                             => true,
-    'mozorg/about.lang'                       => false,
-    'mozorg/about/manifesto.lang'             => false,
-    'mozorg/about/history.lang'               => false,
-    'mozorg/about/history-details.lang'       => false,
-    'mozorg/mission.lang'                     => false,
-    'mozorg/contribute.lang'                  => false,
-    'mozorg/plugincheck.lang'                 => true,
-    'mozorg/products.lang'                    => false,
-    'mozorg/home.lang'                        => true,
-    'mozspaces.lang'                          => false,
-    'newsletter.lang'                         => true,
-    'privacy/privacy-day.lang'                => false,
-    'snippets.lang'                           => false,
-    'tabzilla/tabzilla.lang'                  => false,
-    'upgradedialog.lang'                      => true,
-    'upgradepromos.lang'                      => false,
-    'firefox/nightly_firstrun.lang'           => false,
+
+$mozillaorg_flags = [
+    'download.lang'                           => [
+        'critical' => 'all',
+    ],
+    'download_button.lang'                    => [
+        'critical' => 'all',
+    ],
+    'esr.lang'                                => [
+        'critical' => 'none',
+    ],
+    'euballot.lang'                           => [
+        'critical' => 'none',
+    ],
+    'firefox/geolocation.lang'                => [
+        'critical' => 'none',
+    ],
+    'firefox/new.lang'                        => [
+        'critical' => 'all',
+    ],
+    'firefox/channel.lang'                    => [
+        'critical' => 'all',
+    ],
+    'firefox/speed.lang'                      => [
+        'critical' => 'none',
+    ],
+    'firefox/os/index.lang'                   => [
+        'critical' => 'all',
+    ],
+    'firefox/os/faq.lang'                     => [
+        'critical' => 'none',
+    ],
+    'firefox/partners/index.lang'             => [
+        'critical' => 'all',
+    ],
+    'firefox/includes/mwc_2014_schedule.lang' => [
+        'critical' => 'all',
+    ],
+    'firefox/desktop/index.lang'              => [
+        'critical' => 'all',
+    ],
+    'firefox/desktop/customize.lang'          => [
+        'critical' => 'all',
+    ],
+    'firefox/desktop/fast.lang'               => [
+        'critical' => 'all',
+    ],
+    'firefox/desktop/trust.lang'              => [
+        'critical' => 'all',
+    ],
+    'firefox/desktop/tips.lang'               => [
+        'critical' => 'all',
+    ],
+    'firefox/sync.lang'                       => [
+        'critical' => 'all',
+    ],
+    'mwc2014_promos.lang'                     => [
+        'critical' => 'all',
+    ],
+    'firefox/whatsnew.lang'                   => [
+        'critical' => 'all',
+    ],
+    'firefox/installer-help.lang'             => [
+        'critical' => 'all',
+    ],
+    'firefox/australis/firefox_tour.lang'     => [
+        'critical' => 'all',
+    ],
+    'firefoxflicks.lang'                      => [
+        'critical' => 'none',
+    ],
+    'firefoxlive.lang'                        => [
+        'critical' => 'none',
+    ],
+    'firefoxos/firefoxos.lang'                => [
+        'critical' => 'all',
+    ],
+    'firefoxtesting.lang'                     => [
+        'critical' => 'all',
+    ],
+    'foundation/annualreport/2011.lang'       => [
+        'critical' => 'none',
+    ],
+    'foundation/annualreport/2011faq.lang'    => [
+        'critical' => 'all',
+    ],
+    'foundation/annualreport/2012/index.lang' => [
+        'critical' => 'all',
+    ],
+    'foundation/annualreport/2012/faq.lang'   => [
+        'critical' => 'none',
+    ],
+    'foundationsection.lang'                  => [
+        'critical' => 'none',
+    ],
+    'lightbeam/lightbeam.lang'                => [
+        'critical' => 'none',
+    ],
+    'main.lang'                               => [
+        'critical' => 'all',
+    ],
+    'marketplace/marketplace.lang'            => [
+        'critical' => 'all',
+    ],
+    'marketplace/partners.lang'               => [
+        'critical' => 'none',
+    ],
+    'mobile.lang'                             => [
+        'critical' => 'all',
+    ],
+    'mozorg/15years.lang'                     => [
+        'critical' => 'none',
+    ],
+    'mozorg/about.lang'                       => [
+        'critical' => 'none',
+    ],
+    'mozorg/about/manifesto.lang'             => [
+        'critical' => 'none',
+    ],
+    'mozorg/about/history.lang'               => [
+        'critical' => 'none',
+    ],
+    'mozorg/about/history-details.lang'       => [
+        'critical' => 'none',
+    ],
+    'mozorg/mission.lang'                     => [
+        'critical' => 'none',
+    ],
+    'mozorg/contribute.lang'                  => [
+        'critical' => 'none',
+    ],
+    'mozorg/plugincheck.lang'                 => [
+        'critical' => 'all',
+    ],
+    'mozorg/products.lang'                    => [
+        'critical' => 'none',
+    ],
+    'mozorg/home.lang'                        => [
+        'critical' => 'all',
+    ],
+    'mozspaces.lang'                          => [
+        'critical' => 'none',
+    ],
+    'newsletter.lang'                         => [
+        'critical' => 'all',
+    ],
+    'privacy/privacy-day.lang'                => [
+        'critical' => 'none',
+    ],
+    'snippets.lang'                           => [
+        'critical' => 'none',
+    ],
+    'tabzilla/tabzilla.lang'                  => [
+        'critical' => 'none',
+    ],
+    'upgradedialog.lang'                      => [
+        'critical' => 'all',
+    ],
+    'upgradepromos.lang'                      => [
+        'critical' => 'none',
+    ],
+    'firefox/nightly_firstrun.lang'           => [
+        'critical' => 'none',
+    ],
 ];
 
 $no_active_tag = [
@@ -162,7 +271,7 @@ $sites =
         $repo1,
         'locales/',
         $mozilla,
-        array_keys($mozillaorg_lang),
+        array_keys($mozillaorg_flags),
         'en-GB', // source locale
         $public_repo1,
     ],

--- a/libs/functions.inc.php
+++ b/libs/functions.inc.php
@@ -90,25 +90,30 @@ function analyseLangFile($locale, $website, $filename)
     $GLOBALS[$locale]['Obsolete']    = array();
     $GLOBALS[$locale]['python_vars'] = array();
     $GLOBALS[$locale]['tags']        = array();
+    $GLOBALS[$locale]['moztags']     = array();
     $GLOBALS[$locale]['activated']   = false;
-
 
     if (isset($GLOBALS['__l10n_moz'])) {
         foreach ($GLOBALS['__l10n_moz'] as $key => $val) {
-
             if ($key == 'filedescription') {
                 continue;
             }
 
             if ($key == 'activated') {
-                $GLOBALS[$locale]['activated'] = $val;
+                $GLOBALS[$locale]['moztags'][] = $key;
+                //logger($GLOBALS[$locale]['moztags'][0]);
                 continue;
+            }
+            if (array_key_exists($filename, $mozillaorg_flags)) {
+                foreach ($mozillaorg_flags[$filename] as $tag => $locales) {
+                    if ((is_array($locales) && in_array($locale, $locales)) || $locales == 'all') {
+                        if (!array_key_exists($tag, array_flip($GLOBALS[$locale]['moztags']))) {
+                            $GLOBALS[$locale]['moztags'][] = $tag;
+                        }
+                    }
+                }
             }
 
-            if ($key == 'tags') {
-                $GLOBALS[$locale]['tags'] = $val;
-                continue;
-            }
 
             if (array_key_exists($key, $GLOBALS['__english_moz'])) {
 

--- a/views/export.inc.php
+++ b/views/export.inc.php
@@ -37,10 +37,15 @@ foreach ($sites as $key => $_site) {
             $export[$_site[0]][$filename]['missing']    = count($GLOBALS[$locale]['Missing']);
             $export[$_site[0]][$filename]['obsolete']   = count($GLOBALS[$locale]['Obsolete']);
             $export[$_site[0]][$filename]['translated'] = count($GLOBALS[$locale]['Translated']);
+            $export[$_site[0]][$filename]['moztags'] = $GLOBALS[$locale]['moztags'];
 
             if ($_site[0] == 'www.mozilla.org' && array_key_exists($filename, $mozillaorg_lang)) {
-                $export[$_site[0]][$filename]['critical'] = $mozillaorg_lang[$filename];
+                $export[$_site[0]][$filename]['critical'] = $mozillaorg_lang[$filename]['critical'];
             }
+
+
+
+
             if ($_site[0] == 'about:healthreport' && array_key_exists($filename, $firefoxhealthreport_lang)) {
                 $export[$_site[0]][$filename]['critical'] = $firefoxhealthreport_lang[$filename];
             }

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -30,6 +30,7 @@ foreach ($sites[$website][4] as $_file) {
       <th>Obsolete</th>
       <th>Tags</th>
       <th>Activated</th>
+      <th>Moztags</th>
     </tr>
   </thead>
   <tbody>
@@ -58,7 +59,7 @@ foreach ($sites[$website][4] as $_file) {
 
         analyseLangFile($_lang, $website, $_file);
 
-        //~ var_dump($GLOBALS[$_lang]);
+        //var_dump($GLOBALS[$_lang]);
 
         $todo  = count($GLOBALS[$_lang]['Identical']) + count($GLOBALS[$_lang]['Missing']);
         $total = $todo + count($GLOBALS[$_lang]['Translated']);
@@ -114,19 +115,22 @@ foreach ($sites[$website][4] as $_file) {
                 } else {
                     echo $td('');
                 }
-
                 continue;
             }
 
-            if ($key == 'activated') {
-                $json[$_file][$_lang][$key] = $val;
-
-                if ($val) {
-                    echo $td('', 'activated');
+            if ($key == 'moztags') {
+                foreach ($val as $tag) {
+                    if ($tag != 'activated') {
+                        $json[$_file][$_lang][$key][] = $tag;
+                    } else {
+                        echo $td('', 'activated');
+                    }
+                }
+                if (!empty($json[$_file][$_lang][$key])) {
+                    echo $td(implode('<br>', $json[$_file][$_lang][$key]), 'moztags_column');
                 } else {
                     echo $td('');
                 }
-
                 continue;
             }
 
@@ -147,7 +151,7 @@ foreach ($sites[$website][4] as $_file) {
   </tbody>
   <tfoot>
     <tr>
-      <td colspan= "7">'
+      <td colspan= "8">'
         . $count_done
         . ' perfect locales ('
         . round($count_done/count($targetted_locales)*100)


### PR DESCRIPTION
This is not ready, this is a WIP, to get early feedback.

I'll need to update each call to the "critical" API, and probably fix some other things.

So basically, this patch allow to define several tags per page and choose which locale(s) it concern. There are two keywords, 'all' for all locales, 'none' when it's always false. When a tag concern only some locales, we can define an array with the locales instead of the keyword.
What do you think?
