### PR TITLE
Extract tag bindings starting with ## TAG: tag_name

### DIFF
--- a/lang_update
+++ b/lang_update
@@ -123,13 +123,13 @@ foreach ($files as $filename) {
                 }
             }
             /* incorporate strings from other lang files */
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey1.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey2.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey3.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey4.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey5.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/snippets.lang');
-            // l10n_moz::load($sites[$website][1] . $sites[$website][2] . $lang . '/mozorg/about.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey1.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey2.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey3.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey4.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/survey5.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/snippets.lang');
+            // DotLangParser::load($sites[$website][1] . $sites[$website][2] . $lang . '/mozorg/about.lang');
 
             $GLOBALS['__l10n_moz']['activated'] = (boolean) $activeStatus;
             $GLOBALS['__l10n_moz']['locale_code'] = $lang;

--- a/libs/functions.inc.php
+++ b/libs/functions.inc.php
@@ -85,13 +85,14 @@ function analyseLangFile($locale, $website, $filename)
     DotLangParser::load($path);
 
     /* define sub-arrays for a locale */
-    $GLOBALS[$locale]['Identical']   = array();
-    $GLOBALS[$locale]['Translated']  = array();
-    $GLOBALS[$locale]['Missing']     = array();
-    $GLOBALS[$locale]['Obsolete']    = array();
-    $GLOBALS[$locale]['python_vars'] = array();
-    $GLOBALS[$locale]['tags']        = array();
-    $GLOBALS[$locale]['activated']   = false;
+    $GLOBALS[$locale]['Identical']    = [];
+    $GLOBALS[$locale]['Translated']   = [];
+    $GLOBALS[$locale]['Missing']      = [];
+    $GLOBALS[$locale]['Obsolete']     = [];
+    $GLOBALS[$locale]['python_vars']  = [];
+    $GLOBALS[$locale]['tags']         = [];
+    $GLOBALS[$locale]['tag_bindings'] = [];
+    $GLOBALS[$locale]['activated']    = false;
 
 
     if (isset($GLOBALS['__l10n_moz'])) {
@@ -108,6 +109,11 @@ function analyseLangFile($locale, $website, $filename)
 
             if ($key == 'tags') {
                 $GLOBALS[$locale]['tags'] = $val;
+                continue;
+            }
+
+            if ($key == 'tag_bindings') {
+                $GLOBALS[$locale]['tag_bindings'] = $val;
                 continue;
             }
 
@@ -152,7 +158,7 @@ function analyseLangFile($locale, $website, $filename)
 
         foreach ($GLOBALS['__english_moz'] as $key => $val) {
 
-            if (in_array($key, ['filedescription', 'activated', 'tags'])) {
+            if (in_array($key, ['filedescription', 'activated', 'tags', 'tag_bindings'])) {
                 continue;
             }
 
@@ -295,7 +301,9 @@ function buildFile($eol, $exceptions = [])
     }
 
     foreach ($GLOBALS['__english_moz'] as $key => $val) {
-        if ($key == 'activated' || $key == 'tags') {
+        if ($key == 'activated' ||
+            $key == 'tags' ||
+            $key == 'tag_bindings') {
             continue;
         }
 

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -250,3 +250,12 @@ table.listpages tr td:first-child {
     min-width: 250px;
     padding: 2px 6px;
 }
+
+/* Translate page */
+
+.tag {
+    font-size: 75%;
+    padding: 0.2em 0.6em;
+    border-radius: 0.25em;
+    margin: 0 10px;
+}

--- a/tests/testfiles/dotlang/toto.lang
+++ b/tests/testfiles/dotlang/toto.lang
@@ -1,3 +1,4 @@
+## active ##
 ## I am a tag ##
 
 ## NOTE: I am metadata
@@ -32,4 +33,11 @@ Courrier
 ;Hello
 Bonjour
 
+
+;Empty string
+
+
+## TAG: bound tag
+;String with tag
+Chaîne avec étiquette
 

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -1,7 +1,8 @@
 <?php
-namespace Langchecker\tests\units;
+namespace tests\units\Langchecker;
 
 use atoum;
+use Langchecker\DotLangParser as _DotLangParser;
 
 require_once __DIR__ . '/../bootstrap.php';
 
@@ -11,10 +12,11 @@ class DotLangParser extends atoum\test
     {
         $test_file = __DIR__ . '/../../testfiles/dotlang/toto.lang';
 
-        return array(
+        return [
             [
                 $test_file,
                 [
+                    '## active ##',
                     '## I am a tag ##',
                     '## NOTE: I am metadata',
                     '# I am a comment',
@@ -25,9 +27,13 @@ class DotLangParser extends atoum\test
                     '# another comment',
                     ';Hello',
                     'Bonjour',
+                    ';Empty string',
+                    '## TAG: bound tag',
+                    ';String with tag',
+                    'Chaîne avec étiquette',
                 ]
             ]
-        );
+        ];
     }
 
     /**
@@ -35,9 +41,92 @@ class DotLangParser extends atoum\test
      */
     public function testGetFile($a, $b)
     {
-        $obj = new \Langchecker\DotLangParser();
+        $obj = new _DotLangParser();
         $this
             ->array($obj->getFile($a))
                 ->isEqualTo($b);
+    }
+
+    public function testLoadLocale()
+    {
+        $obj = new _DotLangParser();
+
+        // Load file as French
+        $test_file = __DIR__ . '/../../testfiles/dotlang/toto.lang';
+        $GLOBALS['reflang'] = 'fr';
+        $obj->load($test_file);
+
+        // Check activation status
+        $this
+            ->boolean($GLOBALS['__l10n_moz']['activated'])
+                ->isTrue();
+
+        // Check file description
+        $this
+            ->array($GLOBALS['__l10n_moz']['filedescription'])
+                ->isEqualTo(['I am metadata']);
+
+        // Check tags
+        $this
+            ->array($GLOBALS['__l10n_moz']['tags'])
+                ->isEqualTo(['I am a tag']);
+
+        // Check translation of one string
+        $this
+            ->string($GLOBALS['__l10n_moz']['Hello'])
+                ->isEqualTo('Bonjour');
+
+        // Check fallback to English for missing translation
+        $this
+            ->string($GLOBALS['__l10n_moz']['Empty string'])
+                ->isEqualTo('Empty string');
+    }
+
+    public function testLoadEnglish()
+    {
+        $obj = new _DotLangParser();
+
+        /* Load file as English. Some info (comments, bound tags)
+         * are extracted only for English
+         */
+        $test_file = __DIR__ . '/../../testfiles/dotlang/toto.lang';
+        $GLOBALS['reflang'] = 'en-US';
+        $obj->load($test_file);
+
+        // Check comments
+        $this
+            ->integer(count($GLOBALS['__l10n_comments']))
+                ->isEqualTo(2);
+        $this
+            ->string($GLOBALS['__l10n_comments']['Browser'])
+                ->isEqualTo('I am a comment');
+
+        // Check bound tags
+        $this
+            ->integer(count($GLOBALS['__english_moz']['tag_bindings']))
+                ->isEqualTo(1);
+        $this
+            ->string($GLOBALS['__english_moz']['tag_bindings']['String with tag'])
+                ->isEqualTo('bound tag');
+    }
+
+    public function startsWithDP()
+    {
+        return [
+            ['test string', 't'],
+            [';test string', ';'],
+            ['## TAG: test string', '## TAG:'],
+        ];
+    }
+
+    /**
+     * @dataProvider startsWithDP
+     */
+    public function testStartsWith($a, $b)
+    {
+        $obj = new _DotLangParser();
+        $this
+            ->boolean($obj->startsWith($a, $b))
+                ->isTrue();
     }
 }

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -22,9 +22,10 @@ foreach ($sites[$website][4] as $_file) {
 
     getEnglishSource($reflang, $website, $_file);
 
+    $translation_link = "?website={$website}&amp;file={$_file}&amp;action=translate";
     echo '
 <table class="sortable globallist">
-  <caption class="filename">' . $_file . '</caption>
+  <caption class="filename"><a href="' . $translation_link . '" title="View available translations for this file">' . $_file . '</a></caption>
   <thead>
     <tr>
       <th>Locale</th>
@@ -96,7 +97,7 @@ foreach ($sites[$website][4] as $_file) {
                         . "{$content}</td>\n";
             };
 
-            if ($key == 'python_vars') {
+            if ($key == 'python_vars' || $key == 'tag_bindings') {
                 continue;
             }
 

--- a/views/json.inc.php
+++ b/views/json.inc.php
@@ -38,7 +38,7 @@ foreach ($GLOBALS['__english_moz'] as $k => $v) {
 
     $sha1 = sha1($k);
 
-    if (in_array($k, ['filedescription', 'activated','tags'])) {
+    if (in_array($k, ['filedescription', 'activated', 'tags', 'tag_bindings'])) {
         continue;
     }
 

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -99,7 +99,7 @@ foreach ($sites as $key => $_site) {
                             "        <tr>\n";
 
                 foreach ($GLOBALS[$locale] as $k => $v) {
-                    if (in_array($k, ['Obsolete', 'python_vars', 'activated', 'tags'])) {
+                    if (in_array($k, ['Obsolete', 'python_vars', 'activated', 'tags', 'tag_bindings'])) {
                         continue;
                     }
                     $todoFiles .= '          <td>' . count($GLOBALS[$locale][$k]) . "</td>\n";

--- a/views/translatestrings.inc.php
+++ b/views/translatestrings.inc.php
@@ -69,15 +69,31 @@ getEnglishSource($reflang, $target, $filename);
                       : $sites[$target][3];
 $val = 0;
 
-foreach ($GLOBALS['__english_moz'] as $k => $v) {
+$bg_colors = ['#459E09', '#B29EF9', '#2D68BA', '#E39530', '#D6D6D4',
+              '#E3309E', '#FF4040', '#F5F562', '#F562C7', '#C0FCF2'];
+$font_colors = ['#FFF', '#FFF', '#FFF', '#FFF', '#000',
+                '#FFF', '#FFF', '#000', '#FFF', '#000'];
 
-    if (in_array($k, ['filedescription', 'activated', 'tags'])) {
+foreach ($GLOBALS['__english_moz'] as $k => $v) {
+    if (in_array($k, ['filedescription', 'activated', 'tags', 'tag_bindings'])) {
         continue;
     }
 
+    $tag_bindings = $GLOBALS['__english_moz']['tag_bindings'];
+    // I want keys in $available_tags to be progressive
+    $available_tags = array_values(array_unique(array_values($tag_bindings)));
+    $header_string = trim(str_replace('{l10n-extra}', '', htmlspecialchars($k)));
+    if (isset($tag_bindings[$k])) {
+        $current_tag = $tag_bindings[$k];
+        $tag_number = array_search($current_tag, $available_tags);
+        $style = "style='background-color: {$bg_colors[$tag_number]}; color: {$font_colors[$tag_number]};'";
+        $header_string .= "</a><span title='Associated tag' class='tag' {$style}>" . $current_tag . "</span>";
+    } else {
+        $header_string .= "</a>";
+    }
+
     echo "<p><a href='#'  style=\"color:green\" onclick=\"showhide('table$val');return false;\">"
-         . trim(str_replace('{l10n-extra}', '', htmlspecialchars($k)))
-         . "</a></p>";
+         . $header_string . "</p>";
 
     echo "<table style='width:100%; display:{$show_status};' id='table$val'>";
 


### PR DESCRIPTION
- Error view: manage missing tags, extra tags, tags enabled with missing strings.
- Global status: add a link in the header to translatestrings.
- Translate strings: display a tag near strings bound to tags.
- lang_update, json, listsitesforlocale: ignore tag_bindings.

On purpose, these are not moved around by lang_update, they live only in the source locale.

It should be safe for [mozilla.org parser](https://github.com/mozilla/bedrock/blob/master/lib/l10n_utils/dotlang.py#L62-L64), not sure about Locamotion.

For testing, you might want to apply [this patch](https://pastebin.mozilla.org/5460056) to the en-GB folder.
