### PR TITLE
Move template selection in class, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ List of supported locale for a specific *PROJECTID* in JSON format. Available pr
 List of supported websites and pages.
 
 ```
-/?action=translated&file=FILEID
+/?action=translate&file=FILEID
 ```
 Display a page with all available translations of *FILEID*.
 
@@ -65,9 +65,9 @@ Display a page with all available translations of *FILEID*.
 Display status of locale with code *LOCALEID*. Add ```&json``` to get data in JSON format.
 
 ```
-/?website=SITEID&file=FILEID&locale=all
+/?website=SITEID&file=FILEID
 ```
-Display global status of *FILEID*. Add ```&json``` to get data in JSON format.
+Display global status of *FILEID*. Add ```&json``` to get data in JSON format, ```&json&locale=XXX``` to get only data for a specific locale.
 
 ## lang_update syntax
 

--- a/classes/Langchecker/Project.php
+++ b/classes/Langchecker/Project.php
@@ -147,10 +147,9 @@ class Project
     /*
      * Return user base coverage for list of locales
      *
-     * @param   array   $locales Array of locales
-     * @return  string           Percent value of our coverage for the user base
+     * @param   array   $locales  Array of locales
+     * @return  string            Percent value of our coverage for the user base
      */
-
     public static function getUserBaseCoverage($locales, $adu)
     {
         if (isset($adu['ja']) && isset($adu['ja-JP-mac'])) {
@@ -169,5 +168,84 @@ class Project
         $locales = array_intersect_key($adu, array_flip($locales));
 
         return number_format(array_sum($locales) / (array_sum($adu) - $english_adu) *100, 2);
+    }
+
+    /*
+     * Return name of the view based on the request parameters
+     *
+     * @param   array   $request  Array of params extracted from URL
+     * @return  array             Array with name of the file to use, if we need a template or not and its name
+     */
+    public static function selectView($request)
+    {
+        // Default: use template called 'template', show list of locales
+        $result['template'] = 'template';
+        $result['file'] = 'listlocales';
+
+        // All URLs with 'action' don't require other values like locale, etc.
+        if ($request['action'] != '') {
+            switch ($request['action']) {
+                case 'activation':
+                    $result['file'] = 'activation';
+                    break;
+                case 'api':
+                    $result['file'] = 'json';
+                    $result['template'] = '';
+                    break;
+                case 'count':
+                    $result['file'] = 'countstrings';
+                    if ($request['json']) {
+                        $result['template'] = '';
+                    }
+                    break;
+                case 'coverage':
+                    $result['file'] = 'getcoverage';
+                    $result['template'] = '';
+                    break;
+                case 'errors':
+                    $result['file'] = 'errors';
+                    break;
+                case 'listlocales':
+                    if ($request['json']) {
+                        $result['file'] = 'listlocalesforproject';
+                        $result['template'] = '';
+                    }
+                    break;
+                case 'listpages':
+                    $result['file'] = 'listpages';
+                    break;
+                case 'translate':
+                    $result['file'] = 'translatestrings';
+                    break;
+            }
+
+            return $result;
+        }
+
+        if ($request['filename'] != '' && $request['website'] != '') {
+            $result['file'] = 'globalstatus';
+            if ($request['json']) {
+                $result['template'] = '';
+            }
+
+            return $result;
+        }
+
+        if ($request['locale'] != '' &&
+            $request['website'] == ''  &&
+            ($request['serial'] || $request['json'])) {
+            $result['file'] = 'export';
+            $result['template'] = '';
+
+            return $result;
+        }
+
+        if ($request['locale'] != '' && $request['website'] == '') {
+            $result['file'] = 'listsitesforlocale';
+
+            return $result;
+        }
+
+        return $result;
     }
 }

--- a/inc/init.php
+++ b/inc/init.php
@@ -16,9 +16,21 @@ require $conf . 'locales.inc.php';
 require $conf . 'sources.inc.php';
 
 // User provided variables
-$filename = isset($_GET['file'])    ? Utils::secureText($_GET['file'])    : '';
-$locale   = isset($_GET['locale'])  ? Utils::secureText($_GET['locale'])  : ''; // Which locale are we analysing? No default
-$website  = isset($_GET['website']) ? Utils::secureText($_GET['website']) : ''; // Which website are we looking at?
-$action   = isset($_GET['action'])  ? Utils::secureText($_GET['action'])  : '';
-$serial   = isset($_GET['serial']); // Do we want serialize data for the webdashboard?
-$json     = isset($_GET['json']);   // Do we want json data for the webdashboard?
+$get_param = function($param, $fallback = '') {
+    if (isset($_GET[$param])) {
+        return is_bool($fallback)
+               ? true
+               : Utils::secureText($_GET[$param]);
+    }
+
+    return $fallback;
+};
+
+// User provided variables
+$action   = $get_param('action');
+$filename = $get_param('file');
+$json     = $get_param('json', false);   // Do we want json data for the webdashboard?
+$locale   = $get_param('locale');        // Which locale are we analysing? No default
+$project  = $get_param('project');
+$serial   = $get_param('serial', false); // Do we want serialize data for the webdashboard?
+$website  = $get_param('website');       // Which website are we looking at?

--- a/index.php
+++ b/index.php
@@ -3,115 +3,28 @@ namespace Langchecker;
 
 require_once __DIR__ . '/inc/init.php';
 
-$case = 0;
+$request_params = [
+    'action'   => $action,
+    'filename' => $filename,
+    'json'     => $json,
+    'locale'   => $locale,
+    'serial'   => $serial,
+    'website'  => $website,
+];
 
-if ($locale == '' && $action == '') {
-    /* case 1: no locale is requested, we display links to all locales */
-    $case = 1;
-} elseif ($locale == '' && $action == 'errors') {
-    /* case 2: no locale is requested, we display errors for all locales */
-    $case = 2;
-} elseif ($locale == '' && $action == 'activation') {
-    /* case 3: no locale is requested, we display a list of pages completely translated but not activated */
-    $case = 3;
-} elseif ($locale != '' && $website == '' && $serial == false && $json == false) {
-    /* case 4: we have a locale but no website is defined, we display the status page for the locale */
-    $case = 4;
-} elseif ($website != '' && isset($sites[$website]) && $serial == false && $action == '') {
-    /* case 5: we have a website defined and just want to see the global status for lang files on this website */
-    $case = 5;
-} elseif ($locale != '' && $website == '' && $serial == true) {
-    /* case 6: data fetched externally */
-    $case = 6;
-} elseif ($locale != '' && $website == '' && $serial == false && $json == true) {
-    /* case 6: data fetched externally */
-    $case = 6;
-} elseif ($locale == ''  && $serial == false && $action == 'count') {
-    /* case 7: list all locales and give the number of untranslated strings for all of them */
-    $case = 7;
-} elseif ($locale == ''  && $serial == false && $action == 'translate') {
-    /* case 8: list all translations of a string for snippets */
-    $case = 8;
-} elseif ($locale == '' && $json == true && $action == 'listlocales') {
-    /* case 9: list all locales for a given page or project */
-    $case = 9;
-} elseif ($action == 'coverage') {
-    /* case 10: get users base coverage for a list of locales */
-    $case = 10;
-} elseif ($action == 'listpages') {
-    /* case 11: display a list of pages, with links to global status, translate */
-    $case = 11;
+$view_selection = Project::selectView($request_params);
+
+if ($view_selection['template'] !== '') {
+    // I need to use a template
+    $template = $templates . $view_selection['template'] . '.inc.php';
+    $view = $views . $view_selection['file'] . '.inc.php';
+} else {
+    // No template (JSON output)
+    $template = $views . $view_selection['file'] . '.inc.php';
 }
 
-if ($action == 'api') {
-    $case = 12;
-}
-
-
-switch ($case) {
-    case 1:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'listlocales.inc.php';
-        break;
-    case 2:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'errors.inc.php';
-        break;
-    case 3:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'activation.inc.php';
-        break;
-    case 4:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'listsitesforlocale.inc.php';
-        break;
-    case 5:
-        if (!isset($_GET['json'])) {
-            $template = $templates . 'template.inc.php';
-            $view     = $views . 'globalstatus.inc.php';
-        } else {
-            $template = $views . 'globalstatus.inc.php';
-        }
-        break;
-    case 6:
-        // export mode for webdashboard
-        $template = $views . 'export.inc.php';
-        break;
-    case 7:
-        if (!isset($_GET['json'])) {
-            $template = $templates . 'template.inc.php';
-            $view     = $views . 'countstrings.inc.php';
-        } else {
-            $template= $views . 'countstrings.inc.php';
-        }
-        break;
-    case 8:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'translatestrings.inc.php';
-        break;
-    case 9:
-        $template = $views . 'listlocalesforproject.inc.php';
-        break;
-    case 10:
-        $template = $views . 'getcoverage.inc.php';
-        break;
-    case 11:
-        $template = $templates . 'template.inc.php';
-        $view = $views . 'listpages.inc.php';
-        break;
-    case 12:
-        $template = $views . 'json.inc.php';
-        break;
-    default:
-        $template = $templates . 'template.inc.php';
-        $view     = $views . 'listlocales.inc.php';
-        break;
-}
-
-if (isset($view)) {
-    // Extract the view name removing path ($views) and extension ('.inc.php')
-    $viewname = substr($view, strlen($views), -8);
-}
+$viewname = $view_selection['file'];
 
 ob_start();
+
 include $template;

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -134,6 +134,7 @@ td.tags_column {
 
 td.activated {
     background-color: #92CC6E;
+    color: #92CC6E;
 }
 
 td.lightlink a {

--- a/tests/units/Langchecker/Project.php
+++ b/tests/units/Langchecker/Project.php
@@ -234,4 +234,286 @@ class Project extends atoum\test
             ->string($obj->getUserBaseCoverage($a, $b))
                 ->isEqualTo($c);
     }
+
+    public function selectViewDP()
+    {
+        return [
+            [
+                [
+                    'action'   => 'activation',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'activation',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'api',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'json',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'count',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'countstrings',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'count',
+                    'filename' => '',
+                    'json'     => true,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'countstrings',
+                    'template'     => false,
+                ],
+            ],
+            [
+                [
+                    'action'   => 'coverage',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'getcoverage',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'errors',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'errors',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'listlocales',
+                    'filename' => '',
+                    'json'     => true,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'listlocalesforproject',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'listlocales',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'listlocales',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'listpages',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',                ],
+                [
+                    'file'         => 'listpages',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => 'translate',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'translatestrings',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => 'test.lang',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '0',
+                ],
+                [
+                    'file'         => 'globalstatus',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => 'test.lang',
+                    'json'     => false,
+                    'locale'   => 'it',
+                    'serial'   => false,
+                    'website'  => '0',
+                ],
+                [
+                    'file'         => 'globalstatus',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => 'test.lang',
+                    'json'     => true,
+                    'locale'   => 'it',
+                    'serial'   => false,
+                    'website'  => '0',
+                ],
+                [
+                    'file'         => 'globalstatus',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => 'test.lang',
+                    'json'     => true,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '0',
+                ],
+                [
+                    'file'         => 'globalstatus',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => 'it',
+                    'serial'   => true,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'export',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => '',
+                    'json'     => true,
+                    'locale'   => 'it',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'export',
+                    'template'     => '',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => true,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'listlocales',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => 'it',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'listsitesforlocale',
+                    'template'     => 'template',
+                ],
+            ],
+            [
+                [
+                    'action'   => '',
+                    'filename' => '',
+                    'json'     => false,
+                    'locale'   => '',
+                    'serial'   => false,
+                    'website'  => '',
+                ],
+                [
+                    'file'         => 'listlocales',
+                    'template'     => 'template',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider selectViewDP
+     */
+    public function testSelectView($a, $b)
+    {
+        $obj = new _Project();
+        $this
+            ->array($obj->selectView($a))
+                ->isEqualTo($b);
+    }
 }

--- a/views/countstrings.inc.php
+++ b/views/countstrings.inc.php
@@ -40,7 +40,7 @@ foreach ($mozilla as $current_locale) {
 arsort($todo);
 $locales_done = 0;
 
-if (isset($_GET['json'])) {
+if ($json) {
     die(Json::output($todo, false, true));
 }
 

--- a/views/listlocalesforproject.inc.php
+++ b/views/listlocalesforproject.inc.php
@@ -4,12 +4,16 @@ namespace Langchecker;
 use \Transvision\Json;
 
 $output_array = [];
-if (isset($_GET['website']) && isset($_GET['file'])) {
-    $current_website = $sites[$_GET['website']];
-    $current_filename = $_GET['file'];
-    $output_array = array_values(Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets));
-} elseif (isset($_GET['project'])) {
-    switch ($_GET['project']) {
+if ($website != '' && $filename != '') {
+    if (isset($sites[$website])) {
+        $current_website = $sites[$website];
+        $current_filename = $filename;
+        if (in_array($current_filename, Project::getWebsiteFiles($current_website))) {
+            $output_array = array_values(Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets));
+        }
+    }
+} elseif ($project != '') {
+    switch ($project) {
         case 'locamotion':
             $output_array = $locamotion_locales;
         break;
@@ -26,6 +30,12 @@ if (isset($_GET['website']) && isset($_GET['file'])) {
             $output_array = $snippets_main_locales;
         break;
     }
+}
+
+if (count($output_array) == 0) {
+    // No locales: either wrong values or not enought parameters
+    http_response_code(400);
+    $output_array[] = 'Please check you request: provide a project name, or a valid couple website+file.';
 }
 
 echo Json::output($output_array, false, true);

--- a/views/translatestrings.inc.php
+++ b/views/translatestrings.inc.php
@@ -15,7 +15,8 @@ namespace Langchecker;
   </script>
 <?php
 
-$current_filename = (isset($_GET['file'])) ? Utils::secureText($_GET['file']) : 'snippets.lang';
+// $filename is set in /inc/init.php
+$current_filename = $filename != '' ? $filename : 'snippets.lang';
 $show_status = isset($_GET['show']) ? 'auto' : 'none';
 
 $supported_file = false;


### PR DESCRIPTION
- Moved template selection logic in Project::selectView, added tests.
- To get global status for a file is not necessary to provide a locale code anymore. If locale code and json are set, returned JSON record include only the requested locale (issue #141).
- Cleaned up $_GET variable, when they're available from inc/init.php ($json, $filename, $website).
- Global status: print an error (and return 400 in JSON mode) if website+file is not supported, avoid warnings for non existent website or locale.
- List locales for project: return code 400 if list of locales is empty. Don't display list of supported locales for website if the file is not valid.
- Renamed local $json variables to $json_data to avoid conflicts with global var $json.
