### PR TITLE
Parser: allow multiple comments

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -157,7 +157,9 @@ class LangManager
         foreach ($reference_data['strings'] as $string_id => $string_value) {
             // Do we have comments for this string?
             if (isset($reference_data['comments'][$string_id])) {
-                echo "# " . $reference_data['comments'][$string_id] . $eol;
+                foreach ($reference_data['comments'][$string_id] as $comment) {
+                    echo "# {$comment}{$eol}";
+                }
             }
 
             $translation = isset($locale_data['strings'][$string_id]) ?

--- a/tests/testfiles/dotlang/en-US/page.lang
+++ b/tests/testfiles/dotlang/en-US/page.lang
@@ -23,6 +23,12 @@ Test
 01
 
 
+# Comment 1
+# Comment 2
+;String with multiple comments
+String with multiple comments
+
+
 # This is the reference locale, shouldn't have a translation. Make sure we use the ID
 ;Press center
 Oh press

--- a/tests/testfiles/dotlang/it/page.lang
+++ b/tests/testfiles/dotlang/it/page.lang
@@ -21,6 +21,10 @@ Ciao
 1
 
 
+;String with multiple comments
+String con più commenti
+
+
 ;Press center
 Sala stampa
 

--- a/tests/testfiles/dotlang/it/updated_page.lang
+++ b/tests/testfiles/dotlang/it/updated_page.lang
@@ -23,6 +23,12 @@ Test
 1
 
 
+# Comment 1
+# Comment 2
+;String with multiple comments
+String con più commenti
+
+
 # This is the reference locale, shouldn't have a translation. Make sure we use the ID
 ;Press center
 Sala stampa

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -104,7 +104,7 @@ class DotLangParser extends atoum\test
             ->integer(count($dotlang_data['comments']))
                 ->isEqualTo(2);
         $this
-            ->string($dotlang_data['comments']['Browser'])
+            ->string($dotlang_data['comments']['Browser'][0])
                 ->isEqualTo('I am a comment');
 
         // Check bound tags

--- a/tests/units/Langchecker/LangManager.php
+++ b/tests/units/Langchecker/LangManager.php
@@ -36,7 +36,7 @@ class LangManager extends atoum\test
 
         $this
             ->integer(count($analysis_data['Translated']))
-                ->isEqualTo(7);
+                ->isEqualTo(8);
 
         $this
             ->integer(count($analysis_data['python_vars']))


### PR DESCRIPTION
Since it’s only used for reference locale, read metadata in a second pass on the file content, consider comments as an array.

I assumed there could be only one comment, realized it's not the case this morning with the [current version of home.lang](http://viewvc.svn.mozilla.org/vc/projects/mozilla.com/trunk/locales/en-GB/mozorg/home.lang?revision=130241&view=markup). This has two consequences: we read only one comment, we don't [associate the string with the tag](http://l10n.mozilla-community.org/~pascalc/langchecker/?website=0&file=mozorg/home.lang&action=translate) because the TAG binding is too far.
