### PR TITLE
Detect duplicated strings in reference locale, display them in errors view

### DIFF
--- a/classes/Langchecker/DotLangParser.php
+++ b/classes/Langchecker/DotLangParser.php
@@ -88,6 +88,14 @@ class DotLangParser
                     $reference = Utils::leftStrip($current_line, ';');
                     $translation = trim($next_line);
 
+                    if (isset($dotlang_data['strings'][$reference]) &&
+                        $reference_locale) {
+                        /* String is already stored, it's a duplicated string. If it's the reference
+                         * locale I save the string ID to issue a warning where necessary.
+                         */
+                        $dotlang_data['duplicates'][] = $reference;
+                    }
+
                     if (Utils::startsWith($translation, ';') || Utils::startsWith($translation, '#')) {
                         /* Empty translation: what I'm reading as translation is either the next reference string
                          * or the next meta tag (comment, tag binding). I consider this string untranslated.

--- a/tests/testfiles/dotlang/toto.lang
+++ b/tests/testfiles/dotlang/toto.lang
@@ -34,6 +34,10 @@ Courrier
 Bonjour
 
 
+;Hello
+Bonjour
+
+
 ;Empty string
 
 

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -27,6 +27,8 @@ class DotLangParser extends atoum\test
                     '# another comment',
                     ';Hello',
                     'Bonjour',
+                    ';Hello',
+                    'Bonjour',
                     ';Empty string',
                     '## TAG: bound tag',
                     ';String with tag',
@@ -78,6 +80,12 @@ class DotLangParser extends atoum\test
             ->array($dotlang_data['tags'])
                 ->isEqualTo(['I am a tag']);
 
+
+        // Check duplicates (not relevant for localized files)
+        $this
+            ->boolean(isset($dotlang_data['duplicates']))
+                ->isFalse();
+
         // Check translation of one string
         $this
             ->string($dotlang_data['strings']['Hello'])
@@ -106,6 +114,11 @@ class DotLangParser extends atoum\test
         $this
             ->string($dotlang_data['comments']['Browser'][0])
                 ->isEqualTo('I am a comment');
+
+        // Check duplicates
+        $this
+            ->boolean(in_array('Hello', $dotlang_data['duplicates']))
+                ->isTrue();
 
         // Check bound tags
         $this

--- a/views/errors.inc.php
+++ b/views/errors.inc.php
@@ -6,6 +6,8 @@ namespace Langchecker;
 <?php
 
 $htmloutput = '';
+
+// Checks on l10n files
 foreach ($mozilla as $current_locale) {
     $locale_with_errors = false;
     $locale_htmloutput = "\n      <h2>Locale: <a href='?locale={$current_locale}' target='_blank'>{$current_locale}</a></h2>\n";
@@ -156,6 +158,40 @@ foreach ($mozilla as $current_locale) {
     if ($locale_with_errors) {
         $locale_htmloutput .= "      </div>\n\n";
         $htmloutput .= $locale_htmloutput;
+    }
+}
+
+// Checks on reference files
+foreach ($sites as $current_website) {
+    $reference_with_errors = false;
+
+    $current_website_name = Project::getWebsiteName($current_website);
+    $reference_locale = Project::getReferenceLocale($current_website);
+
+    $reference_output = "      <h2>Reference locale: {$reference_locale}</h2>\n";
+    $opening_div = "      <div class='website'>\n" .
+                   "        <h2>{$current_website_name}</h2>\n";
+
+    foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
+        // Load reference strings
+        $reference_data = LangManager::loadSource($current_website, $reference_locale, $current_filename);
+
+        if (isset($reference_data['duplicates'])) {
+            if (! $reference_with_errors) {
+                $reference_with_errors = true;
+                $reference_output .= $opening_div;
+            }
+            $reference_output .= "        <p><strong>{$current_filename}</strong> has duplicated strings</p>\n        <ul>\n";
+            foreach ($reference_data['duplicates'] as $key => $string_id) {
+                $reference_output .= "        <li>" . htmlspecialchars($string_id) . "</li>\n";
+            }
+            $reference_output .= "</ul>\n";
+        }
+    }
+
+    if ($reference_with_errors) {
+        $reference_output .= "      </div>\n\n";
+        $htmloutput .= $reference_output;
     }
 }
 


### PR DESCRIPTION
Noticed today while importing firefox/partners/index.lang for es-MX, I got strange comments now that we accept multiple comments, and I couldn't understand the reason. That's because we have duplicated strings, with different comments.
