### PR TITLE
Display current locale name for single locale status

### DIFF
--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -151,7 +151,7 @@ if ($json) {
     } else {
         // Only one locale
         if (isset($json_data[$current_filename][$locale])) {
-            $single_locale_json[$current_filename]['it'] = $json_data[$current_filename][$locale];
+            $single_locale_json[$current_filename][$locale] = $json_data[$current_filename][$locale];
             echo Json::output($single_locale_json, false, true);
         } else {
             // Unknown locale


### PR DESCRIPTION
I swear I have nothing against the Italian locale, but... ^^

This fixes the displayed locale in http://l10n.mozilla-community.org/~pascalc/langchecker/?file=mozorg/home.lang&website=0&json&locale=fr for instance
