### PR TITLE
Import po: ignore translations starting with ";"

### DIFF
--- a/scripts/import_locamotion
+++ b/scripts/import_locamotion
@@ -37,6 +37,7 @@ if ($cli_locale != 'all' && ! in_array($cli_locale, $locamotion_locales)) {
 // We only support import from mozilla.org
 $current_website = $sites[0];
 $updated_files = [];
+$import_errors = '';
 
 // Create list of files to analyze
 if ($cli_filename == 'all') {
@@ -113,6 +114,13 @@ foreach ($file_list as $current_filename) {
         // Import data from locamotion
         $locamotion_import = LangManager::importLocamotion($locale_data, $current_filename, $current_locale, $locamotion_repo);
 
+        // Check for errors, even if there are no imported strings
+        if ($locamotion_import['errors']) {
+            foreach ($locamotion_import['errors'] as $error_message) {
+                $import_errors .= "* {$error_message}\n";
+            }
+        }
+
         if (! $locamotion_import['imported']) {
             continue;
         } else {
@@ -134,5 +142,11 @@ if ($updated_files) {
     foreach ($updated_files as $filename) {
         $result .= "* {$filename}\n";
     }
+    Utils::logger($result);
+}
+
+if ($import_errors) {
+    $result = "\nThere are errors in the source files:\n";
+    $result .= $import_errors;
     Utils::logger($result);
 }

--- a/scripts/import_po
+++ b/scripts/import_po
@@ -46,3 +46,11 @@ if ($po_import['imported']) {
     Utils::fileForceContent($cli_lang_filename, $content);
     Utils::logger("New strings saved in {$cli_lang_filename}.");
 }
+
+if ($po_import['errors']) {
+    $import_errors = "\nThere are errors in the source files:\n";
+    foreach ($po_import['errors'] as $error_message) {
+        $import_errors .= "* {$error_message}\n";
+    }
+    Utils::logger($import_errors);
+}

--- a/tests/testfiles/gettext/test.lang
+++ b/tests/testfiles/gettext/test.lang
@@ -1,0 +1,34 @@
+;Different by Design
+Different by Design
+
+
+;Proudly <span>non-profit</span>
+Proudly <span>non-profit</span>
+
+
+;Innovating <span>for you</span>
+¡Inovando <span>para ti!</span>
+
+
+;Fast, flexible, <span>secure</span>
+Rápido, flexible, <span>seguro</span>
+
+
+;Thanks for choosing Firefox!
+¡Gracias por elegir Firefox!
+
+
+;As a non-profit, we’re free to innovate on your behalf without any pressure to compromise.
+As a non-profit, we’re free to innovate on your behalf without any pressure to compromise.
+
+
+;Download
+Download {ok}
+
+
+;Download test
+Download test
+
+
+;Empty
+Vuota

--- a/tests/testfiles/gettext/test.po
+++ b/tests/testfiles/gettext/test.po
@@ -27,7 +27,7 @@ msgstr "¡Inovando <span>para ti!</span>"
 
 #: download.lang:17
 msgid "Fast, flexible, <span>secure</span>"
-msgstr "Rápido, flexible, <span>seguro</span>"
+msgstr "Rápido, flexible, seguro"
 
 #: download.lang:21
 msgid "Thanks for choosing Firefox!"
@@ -44,3 +44,11 @@ msgstr ""
 #: identical string
 msgid "Download"
 msgstr "Download"
+
+#: translation starting with ;
+msgid "Download test"
+msgstr ";Scarica test"
+
+#: empty translation
+msgid "Empty"
+msgstr "test"

--- a/tests/units/Langchecker/LangManager.php
+++ b/tests/units/Langchecker/LangManager.php
@@ -3,6 +3,7 @@ namespace tests\units\Langchecker;
 
 use atoum;
 use Langchecker\LangManager as _LangManager;
+use Langchecker\DotLangParser as _DotLangParser;
 
 require_once __DIR__ . '/../bootstrap.php';
 
@@ -86,13 +87,12 @@ class LangManager extends atoum\test
         // Total number of strings
         $this
             ->integer(count($strings))
-                ->isEqualTo(7);
+                ->isEqualTo(9);
 
         // Identical string
         $this
             ->string($strings['Download'])
                 ->isEqualTo('Download {ok}');
-
 
         // Single line string
         $this
@@ -103,5 +103,50 @@ class LangManager extends atoum\test
         $this
             ->string($strings['As a non-profit, we’re free to innovate on your behalf without any pressure to compromise.'])
                 ->isEqualTo('Como una organización sin fines de lucro, somos libres de innovar en tu nombre sin presión o compromiso alguno.');
+    }
+
+    public function testImportLocalPoFile()
+    {
+        $po_filepath = TEST_FILES . 'gettext/test.po';
+        $lang_filepath = TEST_FILES . 'gettext/test.lang';
+        $obj = new _LangManager();
+
+        $locale_data = _DotLangParser::parseFile($lang_filepath, false);
+        $po_import = $obj->importLocalPoFile($po_filepath, $locale_data, false);
+
+        // I should have imported data
+        $this
+            ->boolean($po_import['imported'])
+                ->isTrue();
+
+        // I should have one error
+        $this
+            ->integer(count($po_import['errors']))
+                ->isEqualTo(1);
+
+        // Test one translated string
+        $this
+            ->string($po_import['strings']['Innovating <span>for you</span>'])
+                ->isEqualTo('¡Inovando <span>para ti!</span>');
+
+        // Test one translated string in both lang and po file (second has precedence)
+        $this
+            ->string($po_import['strings']['Fast, flexible, <span>secure</span>'])
+                ->isEqualTo('Rápido, flexible, seguro');
+
+        // Empty translation in .po file, existing in .lang file
+        $this
+            ->string($po_import['strings']['Empty'])
+                ->isEqualTo('test');
+
+        // Test one identical string
+        $this
+            ->string($po_import['strings']['Download'])
+                ->isEqualTo('Download {ok}');
+
+        // Test one translation starting with ; (should be ignored)
+        $this
+            ->string($po_import['strings']['Download test'])
+                ->isEqualTo('Download test');
     }
 }


### PR DESCRIPTION
Also add tests for importLocalPoFile (altered the original method to optionally avoid output console).

Issue became evident after displaying the list of updated files after import from Locamotion ([#157](https://github.com/pascalchevrel/langchecker/pull/157)): I kept getting an update from ms/snippets.lang, but then no changes to the .lang file. 

Translation in the .po file [started](https://github.com/translate/mozilla-lang/commit/5a1a4fb851509ab362027e5767136362640e5523) with ";", so the system considered this an extra source string.

We can either strip the starting ";", or just ignore the translation, I choose to ignore it and display warnings during import.
