### PR TITLE
Catch more Python errors

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -55,8 +55,9 @@ class LangManager
                     // Store in translated strings
                     $analysis_data['Translated'][] = $key;
 
-                    // Test if all Python variables are present
-                    $regex = '#%\(' . '[a-z0-9._-]+' .'\)s#';
+                    /* Test if all Python variables are present, analyzing both
+                     * format %(var)s or %s, or 'escaped' percentage sign (%%) */
+                    $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
                     preg_match_all($regex, $reference_data['strings'][$key], $matches1);
                     preg_match_all($regex, $val, $matches2);
 

--- a/classes/Langchecker/Utils.php
+++ b/classes/Langchecker/Utils.php
@@ -92,7 +92,7 @@ class Utils
     public static function highlightPythonVar($origin)
     {
         $origin = htmlspecialchars($origin);
-        $regex = '#%\(' . '[a-z0-9._-]+' . '\)s#';
+        $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
         preg_match_all($regex, $origin, $matches);
         foreach ($matches[0] as $python_var) {
             $origin = str_replace($python_var, "<em>${python_var}</em>", $origin);

--- a/tests/testfiles/dotlang/en-US/page.lang
+++ b/tests/testfiles/dotlang/en-US/page.lang
@@ -49,3 +49,11 @@ String with %(num)s tags
 
 ;Second string with %(num)s tags
 Second string with %(num)s tags
+
+
+;Third string with %s tags
+Third string with %s tags
+
+
+;Fourth string with 90%% coverage
+Fourth string with 90%% coverage

--- a/tests/testfiles/dotlang/it/page.lang
+++ b/tests/testfiles/dotlang/it/page.lang
@@ -43,3 +43,11 @@ Seconda stringa con %(num)s etichette
 
 ;Obsolete string
 Stringa obsoleta
+
+
+;Third string with %s tags
+Terza stringa con variabile mancante
+
+
+;Fourth string with 90%% coverage
+Quarta stringa con copertura al 90%

--- a/tests/testfiles/dotlang/it/updated_page.lang
+++ b/tests/testfiles/dotlang/it/updated_page.lang
@@ -51,3 +51,11 @@ Stringa con etichette e variabile sbagliata
 Seconda stringa con %(num)s etichette
 
 
+;Third string with %s tags
+Terza stringa con variabile mancante
+
+
+;Fourth string with 90%% coverage
+Quarta stringa con copertura al 90%
+
+

--- a/tests/units/Langchecker/LangManager.php
+++ b/tests/units/Langchecker/LangManager.php
@@ -37,11 +37,11 @@ class LangManager extends atoum\test
 
         $this
             ->integer(count($analysis_data['Translated']))
-                ->isEqualTo(8);
+                ->isEqualTo(10);
 
         $this
             ->integer(count($analysis_data['python_vars']))
-                ->isEqualTo(1);
+                ->isEqualTo(3);
 
         $this
             ->string($analysis_data['python_vars']['String with %(num)s tags']['text'])


### PR DESCRIPTION
Noticed these days a couple of errors we don't catch:
- variables with format `%s`
- `%%` (we have one in history-details.lang, caught last week for one locale)

This is currently showing 2 errors for Hebrew, I wonder if the first one is actually an error (I think so, and also the string seems unused, PHP stuff?).

```
;Except where otherwise <a href="%s">noted</a>, content on this site is licensed under the <br /><a href="%s">Creative Commons Attribution Share-Alike License v3.0</a> or any later version.
התוכן באתר זה הנו תחת רישיון <a href="%2$s">Creative Commons Attribution Share-Alike License v3.0</a> או גרסאות מאוחרות יותר, אלא אם <a href="%1$s">צויין</a> אחרת.
```
