### PR TITLE
Add raw files support to Langchecker

### DIFF
--- a/classes/Langchecker/Project.php
+++ b/classes/Langchecker/Project.php
@@ -180,6 +180,35 @@ class Project
     }
 
     /*
+     * Return websites that use a specific data type as source
+     *
+     * @param   array   $sites    Array of all supported websites
+     * @param   array   $type     Type of data (lang, raw)
+     * @return  array             Array of website records
+     */
+    public static function getWebsitesByDataType($sites, $type)
+    {
+        foreach ($sites as $key => $site) {
+            if (self::getWebsiteDataType($site) != $type) {
+                unset($sites[$key]);
+            }
+        }
+
+        return $sites;
+    }
+
+    /*
+     * Return data type used by website
+     *
+     * @param   array   $website  Website data
+     * @return  string            Type of data (lang, raw)
+     */
+    public static function getWebsiteDataType($website)
+    {
+        return $website[8];
+    }
+
+    /*
      * Return user base coverage for list of locales
      *
      * @param   array   $locales  Array of locales

--- a/classes/Langchecker/RawManager.php
+++ b/classes/Langchecker/RawManager.php
@@ -1,0 +1,66 @@
+<?php
+namespace Langchecker;
+
+/*
+ * RawManager class
+ *
+ * This class is used to compare reference and localized "raw" files.
+ * Unlike .lang files, we can't parse content in raw files
+ * (e.g. text files), so we can only determine their status based on
+ * content comparison (through sha1 hashes) and dates.
+ *
+ * @package Langchecker
+ */
+class RawManager
+{
+    /*
+     * Compare reference and localized raw file
+     *
+     * @param   array   $website   Website data
+     * @param   string  $locale    Locale to analyze
+     * @param   string  $filename  File to analyze
+     * @return  array              Results from comparison
+     */
+    public static function compareRawFiles($website, $locale, $filename)
+    {
+        $results = [];
+
+        // Store reference file hash and last update date
+        $reference_locale = Project::getReferenceLocale($website);
+        $reference_filename = Project::getLocalFilePath($website, $reference_locale, $filename);
+        if (file_exists($reference_filename)) {
+            $reference_content = sha1_file($reference_filename);
+            $results['reference_exists'] = true;
+            $results['reference_url'] = Project::getPublicFilePath($website, $reference_locale, $filename);
+            $results['reference_lastupdate'] = Utils::getSVNCommitTimestamp($reference_filename);
+        } else {
+            $results['reference_exists'] = false;
+            $results['cmp_result'] = 'missing_reference';
+        }
+
+        // Generate locale file hash and last update date
+        $locale_filename = Project::getLocalFilePath($website, $locale, $filename);
+        if (file_exists($locale_filename)) {
+            $locale_content = sha1_file($locale_filename);
+            $results['locale_exists'] = true;
+            $results['locale_url'] = Project::getPublicFilePath($website, $locale, $filename);
+            $results['locale_lastupdate'] = Utils::getSVNCommitTimestamp($locale_filename);
+
+            if ($results['reference_exists']) {
+                if ($locale_content == $reference_content) {
+                    $results['cmp_result'] = 'untranslated';
+                } elseif ($results['reference_lastupdate'] > $results['locale_lastupdate']) {
+                    // I check dates only if content is not identical
+                    $results['cmp_result'] = 'outdated';
+                } else {
+                    $results['cmp_result'] = 'ok';
+                }
+            }
+        } else {
+            $results['locale_exists'] = false;
+            $results['cmp_result'] = 'missing_locale';
+        }
+
+        return $results;
+    }
+}

--- a/classes/Langchecker/Utils.php
+++ b/classes/Langchecker/Utils.php
@@ -117,6 +117,26 @@ class Utils
     }
 
     /*
+     * Return
+     *
+     * @param   string $filename  File to analyze
+     * @return  int               Timestamp of last commit from SVN, or local if that fails
+     */
+    public function getSVNCommitTimestamp($filename)
+    {
+        exec("svn info --xml {$filename} 2>/dev/null", $output, $return_code);
+
+        if ($return_code) {
+            return filemtime($filename);
+        }
+
+        $file = new \SimpleXMLElement(implode('', $output));
+        $date = new \DateTime($file->entry->commit->date);
+
+        return $date->getTimestamp();
+    }
+
+    /*
      * Print error, quit application if requested
      *
      * @param  string  $message  Message to display

--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -247,6 +247,67 @@ $lang_flags['firefox-tiles'] = [
     'tiles.lang' => [ 'critical' => ['all'] ],
 ];
 
+$getinvolved_autoreplies = [
+    'templates/mozorg/contribute-2015/activism.txt',
+    'templates/mozorg/contribute-2015/coding_addons.txt',
+    'templates/mozorg/contribute-2015/coding_cloud.txt',
+    'templates/mozorg/contribute-2015/coding_firefox.txt',
+    'templates/mozorg/contribute-2015/coding_firefoxos.txt',
+    'templates/mozorg/contribute-2015/coding_marketplace.txt',
+    'templates/mozorg/contribute-2015/coding_webcompat.txt',
+    'templates/mozorg/contribute-2015/coding_webdev.txt',
+    'templates/mozorg/contribute-2015/dontknow.txt',
+    'templates/mozorg/contribute-2015/education_fellowships.txt',
+    'templates/mozorg/contribute-2015/education_hive.txt',
+    'templates/mozorg/contribute-2015/education_sciencelab.txt',
+    'templates/mozorg/contribute-2015/education_webmaker.txt',
+    'templates/mozorg/contribute-2015/l10n_product.txt',
+    'templates/mozorg/contribute-2015/l10n_tools.txt',
+    'templates/mozorg/contribute-2015/l10n_web.txt',
+    'templates/mozorg/contribute-2015/qa_addons.txt',
+    'templates/mozorg/contribute-2015/qa_general.txt',
+    'templates/mozorg/contribute-2015/qa_marketplace.txt',
+    'templates/mozorg/contribute-2015/qa_webcompat.txt',
+    'templates/mozorg/contribute-2015/sumo_sumo.txt',
+    'templates/mozorg/contribute-2015/sumo_webcompat.txt',
+    'templates/mozorg/contribute-2015/writing_addons.txt',
+    'templates/mozorg/contribute-2015/writing_journalism.txt',
+    'templates/mozorg/contribute-2015/writing_marketplace.txt',
+    'templates/mozorg/contribute-2015/writing_social.txt',
+    'templates/mozorg/contribute-2015/writing_txt_devs.txt',
+    'templates/mozorg/contribute-2015/writing_txt_users.txt',
+];
+$lang_flags['contribute-autoreplies'] = [
+    'templates/mozorg/contribute-2015/activism.txt'              => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_addons.txt'         => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_cloud.txt'          => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_firefox.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_firefoxos.txt'      => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_marketplace.txt'    => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_webcompat.txt'      => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/coding_webdev.txt'         => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/dontknow.txt'              => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/education_fellowships.txt' => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/education_hive.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/education_sciencelab.txt'  => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/education_webmaker.txt'    => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/l10n_product.txt'          => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/l10n_tools.txt'            => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/l10n_web.txt'              => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/qa_addons.txt'             => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/qa_general.txt'            => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/qa_marketplace.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/qa_webcompat.txt'          => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/sumo_sumo.txt'             => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/sumo_webcompat.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_addons.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_journalism.txt'    => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_marketplace.txt'   => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_social.txt'        => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_txt_devs.txt'      => [ 'optional' => ['all'] ],
+    'templates/mozorg/contribute-2015/writing_txt_users.txt'     => [ 'optional' => ['all'] ],
+];
+
 $slogans_locales = ['bg', 'ca', 'cs', 'de', 'el', 'el', 'es-ES', 'fr', 'hu', 'hr', 'it',
                     'ja', 'ko',  'pl', 'pt-BR', 'ro', 'sr', 'sr-Latn', 'zh-CN', 'zh-TW'];
 
@@ -269,6 +330,10 @@ $firefox_updater_locales = ['ar', 'cs', 'de', 'el', 'es-ES', 'fi', 'fr', 'hu', '
 $fxos_marketing = ['bg', 'bn-BD', 'cs', 'de', 'el', 'es-ES', 'fr', 'hi-IN', 'hr', 'hu', 'it', 'ja',
                    'mk', 'pl', 'pt-BR', 'ro', 'ru', 'sr', 'sr-Latn', 'ta', 'tr', 'zh-CN'];
 
+$getinvolved_autoreplies_locales = ['bn-BD', 'de', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'ff', 'fr',
+                                    'hi-IN', 'hr', 'id', 'it', 'ms', 'nl', 'pl', 'pt-BR', 'ru',
+                                    'sq', 'sr', 'tr', 'zh-CN', 'zh-TW'];
+
 /* Array structure for single website
 *
 *   [
@@ -280,6 +345,7 @@ $fxos_marketing = ['bg', 'bn-BD', 'cs', 'de', 'el', 'es-ES', 'fr', 'hi-IN', 'hr'
 *       5 reference locale,
 *       6 url to public repo,
 *       7 array of flags,
+*       8 type of files (lang, raw)
 *   ]
 *
 */
@@ -295,6 +361,7 @@ $sites =
         'en-GB', // source locale
         $public_repo1,
         $lang_flags['www.mozilla.org'],
+        'lang',
     ],
 
     1 => [
@@ -306,6 +373,7 @@ $sites =
         'en-US', // source locale
         $public_repo2,
         [],
+        'lang',
     ],
 
     2 => [
@@ -318,6 +386,7 @@ $sites =
         'en-GB', // source locale
         $public_repo3,
         [],
+        'lang',
     ],
 
     3 => [
@@ -329,6 +398,7 @@ $sites =
         'en-US', // source locale
         $public_repo4,
         [],
+        'lang',
     ],
 
     4 => [
@@ -340,6 +410,7 @@ $sites =
         'en-US', // source locale
         $public_repo5,
         $lang_flags['about:healthreport'],
+        'lang',
     ],
 
     5 => [
@@ -351,6 +422,7 @@ $sites =
         'en-US', // source locale
         $public_repo6,
         $lang_flags['slogans'],
+        'lang',
     ],
 
     6 => [
@@ -362,6 +434,7 @@ $sites =
         'en-US', // source locale
         $public_repo7,
         $lang_flags['snippets'],
+        'lang',
     ],
 
     7 => [
@@ -373,6 +446,7 @@ $sites =
         'en-US', // source locale
         $public_repo8,
         $lang_flags['add-ons'],
+        'lang',
     ],
 
     8 => [
@@ -384,6 +458,7 @@ $sites =
         'en-US', // source locale
         $public_repo9,
         $lang_flags['firefox-updater'],
+        'lang',
     ],
 
     9 => [
@@ -395,6 +470,7 @@ $sites =
         'en-US', // source locale
         $public_repo10,
         $lang_flags['firefoxos-marketing'],
+        'lang',
     ],
 
     10 => [
@@ -406,6 +482,19 @@ $sites =
         'en-US', // source locale
         $public_repo11,
         $lang_flags['firefox-tiles'],
+        'lang',
+    ],
+
+    11 => [
+        'contribute-autoreplies',
+        $repo1,
+        'locales/',
+        $getinvolved_autoreplies_locales,
+        $getinvolved_autoreplies,
+        'en-GB', // source locale
+        $public_repo1,
+        $lang_flags['contribute-autoreplies'],
+        'raw',
     ],
 ];
 

--- a/inc/init.php
+++ b/inc/init.php
@@ -1,6 +1,8 @@
 <?php
 namespace Langchecker;
 
+date_default_timezone_set('Europe/Paris');
+
 // Server shortcuts
 $approot   = __DIR__ . '/../';
 $libs      = $approot . 'libs/';

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -252,6 +252,56 @@ div.tip blockquote {
     color: rgba(80, 80, 80, 1)
 }
 
+span.datasource {
+    font-size: 12px;
+    padding: 0.2em 0.4em;
+    border-radius: 0.25em;
+    margin: 0 6px;
+    display: inline-block;
+    background: #9e988b;
+    text-transform: uppercase;
+    color: #fff;
+    position: relative;
+    top: -10px;
+}
+
+.rawfiles {
+    margin-bottom: 10px;
+}
+
+.rawfiles td {
+    padding: 2px 6px;
+}
+
+.rawfiles .maincolumn {
+    text-align: left;
+}
+
+.rawfiles .rawstatus {
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.rawfiles .untranslated {
+    color: #ff5b52;
+}
+
+.rawfiles .outdated {
+    color: #ffbd52;
+}
+
+.rawfiles .missing_reference,
+.rawfiles .missing_locale {
+    color: #82817f;
+}
+
+.rawfiles .ok {
+    color: #92cc6e;
+}
+
+.rawfiles .last_update {
+    font-size: 80%;
+}
 
 /* List pages */
 

--- a/scripts/lang_update
+++ b/scripts/lang_update
@@ -15,11 +15,13 @@ $cli_website  = Utils::getCliParam(2, $argv, '0');                   // Which we
 $cli_locale   = Utils::getCliParam(3, $argv, 'all');                 // Which locale are we analyzing? No default
 $single_file_mode = $cli_filename != 'all' && $cli_locale != 'all';  // One locale, one file
 
-if (! isset($sites[$cli_website])) {
+$lang_based_sites = Project::getWebsitesByDataType($sites, 'lang');
+
+if (! isset($lang_based_sites[$cli_website])) {
     Utils::logger("Unknown website #{$cli_website}.", "quit");
 }
 
-$current_website = $sites[$cli_website];
+$current_website = $lang_based_sites[$cli_website];
 
 // Create list of files to analyze
 if ($cli_filename == 'all') {
@@ -91,7 +93,7 @@ foreach ($file_list as $current_filename) {
         }
 
         // Incorporate strings from other lang files
-        // $temp_data = LangManager::loadSource($sites[0], $current_locale, 'main.lang');
+        // $temp_data = LangManager::loadSource($lang_based_sites[0], $current_locale, 'main.lang');
         // $locale_data['strings'] = array_merge($locale_data['strings'], $temp_data['strings']);
 
         // Exceptions are managed in LangManager::manageStringExceptions

--- a/tests/testfiles/config/sources.php
+++ b/tests/testfiles/config/sources.php
@@ -20,7 +20,8 @@ $sites = [
         ['file1.lang', 'file2.lang'],
         'en-GB',
         '/public/repo1/',
-        $priorities
+        $priorities,
+        'lang',
     ],
 
     1 => [
@@ -31,7 +32,8 @@ $sites = [
         ['file3.lang', 'file4.lang'],
         'en-US',
         '/public/repo2/',
-        []
+        [],
+        'lang',
     ],
 
     2 => [
@@ -42,7 +44,20 @@ $sites = [
         ['page.lang'],
         'en-US',
         '/public/repo3/',
-        []
+        [],
+        'lang',
+    ],
+
+    3 => [
+        'txt_test',
+        __DIR__ . '/../txt/',
+        '',
+        ['en-US', 'it'],
+        ['email1.txt', 'email2.txt', 'email3.txt', 'email4.txt', 'email5.txt'],
+        'en-US',
+        '/public/repo3/',
+        [],
+        'raw',
     ],
 ];
 

--- a/tests/testfiles/txt/en-US/email1.txt
+++ b/tests/testfiles/txt/en-US/email1.txt
@@ -1,0 +1,2 @@
+This is a very simple txt file
+

--- a/tests/testfiles/txt/en-US/email2.txt
+++ b/tests/testfiles/txt/en-US/email2.txt
@@ -1,0 +1,4 @@
+This is a very simple txt file
+
+Second version
+

--- a/tests/testfiles/txt/en-US/email3.txt
+++ b/tests/testfiles/txt/en-US/email3.txt
@@ -1,0 +1,4 @@
+This is a very simple txt file
+
+Third version
+

--- a/tests/testfiles/txt/en-US/email4.txt
+++ b/tests/testfiles/txt/en-US/email4.txt
@@ -1,0 +1,5 @@
+This is a very simple txt file
+
+Fourth version
+
+Added text

--- a/tests/testfiles/txt/it/email1.txt
+++ b/tests/testfiles/txt/it/email1.txt
@@ -1,0 +1,2 @@
+This is a very simple txt file
+

--- a/tests/testfiles/txt/it/email2.txt
+++ b/tests/testfiles/txt/it/email2.txt
@@ -1,0 +1,2 @@
+Testo semplice di esempio.
+

--- a/tests/testfiles/txt/it/email4.txt
+++ b/tests/testfiles/txt/it/email4.txt
@@ -1,0 +1,4 @@
+This is a very simple txt file
+
+Fourth version
+

--- a/tests/testfiles/txt/it/email5.txt
+++ b/tests/testfiles/txt/it/email5.txt
@@ -1,0 +1,2 @@
+Testo semplice di esempio.
+

--- a/tests/units/Langchecker/Project.php
+++ b/tests/units/Langchecker/Project.php
@@ -230,6 +230,41 @@ class Project extends atoum\test
                 ->isEqualTo($c);
     }
 
+    public function testGetWebsitesByDataType()
+    {
+        require_once TEST_FILES . 'config/sources.php';
+
+        $obj = new _Project();
+        $this
+            ->integer(count($obj->getWebsitesByDataType($sites, 'lang')))
+                ->isEqualTo(3);
+
+        $this
+            ->integer(count($obj->getWebsitesByDataType($sites, 'raw')))
+                ->isEqualTo(1);
+    }
+
+    public function getWebsiteDataTypeDP()
+    {
+        require_once TEST_FILES . 'config/sources.php';
+
+        return [
+            [$sites[0], 'lang'],
+            [$sites[3], 'raw'],
+        ];
+    }
+
+    /**
+     * @dataProvider getWebsiteDataTypeDP
+     */
+    public function testGetWebsiteDataType($a, $b)
+    {
+        $obj = new _Project();
+        $this
+            ->string($obj->getWebsiteDataType($a))
+                ->isEqualTo($b);
+    }
+
     public function getUserBaseCoverageDP()
     {
         $adu = [

--- a/tests/units/Langchecker/RawManager.php
+++ b/tests/units/Langchecker/RawManager.php
@@ -1,0 +1,58 @@
+<?php
+namespace tests\units\Langchecker;
+
+use atoum;
+use Langchecker\RawManager as _RawManager;
+use Langchecker\Project as _Project;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class RawManager extends atoum\test
+{
+    public function compareRawFilesDP()
+    {
+        require_once TEST_FILES . 'config/sources.php';
+
+        return [
+            [$sites[3], 'it', 'email1.txt', 'untranslated'],
+            [$sites[3], 'it', 'email2.txt', 'ok'],
+            [$sites[3], 'it', 'email3.txt', 'missing_locale'],
+            [$sites[3], 'it', 'email5.txt', 'missing_reference'],
+        ];
+    }
+
+    /**
+     * @dataProvider compareRawFilesDP
+     */
+    public function testCompareRawFiles($a, $b, $c, $d)
+    {
+        $obj = new _RawManager();
+
+        $file_analysis = $obj->compareRawFiles($a, $b, $c);
+        $this
+            ->string($file_analysis['cmp_result'])
+                ->isEqualTo($d);
+
+    }
+
+    public function testOutdatedCompareRawFiles()
+    {
+        $obj = new _RawManager();
+        require_once TEST_FILES . 'config/sources.php';
+
+        $website = $sites[3];
+        $filename = 'email4.txt';
+
+        // Make localized file 1 hour older than reference file
+        $referencefile = _Project::getLocalFilePath($website, 'en-US', $filename);
+        $timestamp = filemtime($referencefile) - 3600;
+        touch($referencefile);
+        touch(_Project::getLocalFilePath($website, 'it', $filename), $timestamp);
+
+        $file_analysis = $obj->compareRawFiles($website, 'it', $filename);
+        $this
+            ->string($file_analysis['cmp_result'])
+                ->isEqualTo('outdated');
+
+    }
+}

--- a/views/export.inc.php
+++ b/views/export.inc.php
@@ -8,46 +8,58 @@ $current_locale = $locale;
 
 foreach ($sites as $website) {
     if (Project::isSupportedLocale($website, $current_locale)) {
+        $website_data_source = Project::getWebsiteDataType($website);
         foreach (Project::getWebsiteFiles($website) as $filename) {
             if (! Project::isSupportedLocale($website, $current_locale, $filename, $langfiles_subsets)) {
                 // File is not managed for this website+locale, ignore it
                 continue;
             }
 
-            // Load reference strings
             $reference_locale = Project::getReferenceLocale($website);
-            $reference_data = LangManager::loadSource($website, $reference_locale, $filename);
-
             $website_name = Project::getWebsiteName($website);
 
-            $locale_filename = Project::getLocalFilePath($website, $current_locale, $filename);
-            if (! is_file($locale_filename)) {
-                // File is missing
-                continue;
+            $displayed_filename = ($website_data_source == 'lang') ?
+                                  $filename :
+                                  basename($filename);
+
+            if ($website_data_source == 'lang') {
+                // Load reference strings
+                $reference_data = LangManager::loadSource($website, $reference_locale, $filename);
+                $locale_filename = Project::getLocalFilePath($website, $current_locale, $filename);
+                if (! is_file($locale_filename)) {
+                    // File is missing
+                    continue;
+                }
+
+                $locale_analysis = LangManager::analyzeLangFile($website, $current_locale, $filename, $reference_data);
+
+                $export_data[$website_name][$displayed_filename]['identical'] = count($locale_analysis['Identical']);
+                $export_data[$website_name][$displayed_filename]['missing'] = count($locale_analysis['Missing']);
+                $export_data[$website_name][$displayed_filename]['obsolete'] = count($locale_analysis['Obsolete']);
+                $export_data[$website_name][$displayed_filename]['translated'] = count($locale_analysis['Translated']);
+            } else {
+                $file_analysis = RawManager::compareRawFiles($website, $current_locale, $filename);
+                $cmp_result = $file_analysis['cmp_result'];
+                $export_data[$website_name][$displayed_filename]['status'] = $cmp_result;
             }
 
-            $locale_analysis = LangManager::analyzeLangFile($website, $current_locale, $filename, $reference_data);
-
-            $export_data[$website_name][$filename]['identical'] = count($locale_analysis['Identical']);
-            $export_data[$website_name][$filename]['missing'] = count($locale_analysis['Missing']);
-            $export_data[$website_name][$filename]['obsolete'] = count($locale_analysis['Obsolete']);
-            $export_data[$website_name][$filename]['translated'] = count($locale_analysis['Translated']);
+            $export_data[$website_name][$displayed_filename]['data_source'] = $website_data_source;
 
             if (Project::isCriticalFile($website, $filename, $current_locale)) {
-                $export_data[$website_name][$filename]['critical'] = true;
+                $export_data[$website_name][$displayed_filename]['critical'] = true;
             } else {
-                $export_data[$website_name][$filename]['critical'] = false;
+                $export_data[$website_name][$displayed_filename]['critical'] = false;
             }
 
             // Flags
             $file_flags = Project::getFileFlags($website, $filename, $current_locale);
             if ($file_flags) {
-                $export_data[$website_name][$filename]['flags'] = $file_flags;
+                $export_data[$website_name][$displayed_filename]['flags'] = $file_flags;
             }
 
             // Some files have a deadline
             if (isset($deadline[$filename])) {
-                $export_data[$website_name][$filename]['deadline'] = $deadline[$filename];
+                $export_data[$website_name][$displayed_filename]['deadline'] = $deadline[$filename];
             }
         }
     }

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -19,6 +19,7 @@ if (! isset($sites[$website])) {
 }
 
 $current_website = $sites[$website];
+$website_data_source = Project::getWebsiteDataType($current_website);
 
 if ($current_filename == '' || ! in_array($current_filename, Project::getWebsiteFiles($current_website))) {
     if ($json) {
@@ -29,118 +30,186 @@ if ($current_filename == '' || ! in_array($current_filename, Project::getWebsite
     }
 }
 
-$reference_locale = Project::getReferenceLocale($current_website);
-$reference_data = LangManager::loadSource($current_website, $reference_locale, $current_filename);
-
-$translation_link = "?website={$website}&amp;file={$current_filename}&amp;action=translate";
-echo '
-<table class="sortable globallist">
-  <caption class="filename"><a href="' . $translation_link . '" title="View available translations for this file">' . $current_filename . '</a></caption>
-  <thead>
-    <tr>
-      <th>Locale</th>
-      <th>Identical</th>
-      <th>Translated</th>
-      <th>Missing</th>
-      <th>Obsolete</th>
-      <th>Tags</th>
-      <th>Activated</th>
-    </tr>
-  </thead>
-  <tbody>
-';
-
 $complete_locales_count = 0;
 $complete_locales_list = [];
 $json_data = [];
 
-$supported_locales = Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets);
-foreach ($supported_locales as $current_locale) {
-    if ($current_locale == $reference_locale) {
-        // Ignore reference language
-        continue;
+$reference_locale = Project::getReferenceLocale($current_website);
+
+if ($website_data_source == 'lang') {
+    // Websites using .lang files
+    $reference_data = LangManager::loadSource($current_website, $reference_locale, $current_filename);
+
+    $translation_link = "?website={$website}&amp;file={$current_filename}&amp;action=translate";
+    echo '
+    <table class="sortable globallist">
+      <caption class="filename"><a href="' . $translation_link . '" title="View available translations for this file">' . $current_filename . '</a></caption>
+      <thead>
+        <tr>
+          <th>Locale</th>
+          <th>Identical</th>
+          <th>Translated</th>
+          <th>Missing</th>
+          <th>Obsolete</th>
+          <th>Tags</th>
+          <th>Activated</th>
+        </tr>
+      </thead>
+      <tbody>
+    ';
+
+    $supported_locales = Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets);
+    foreach ($supported_locales as $current_locale) {
+        if ($current_locale == $reference_locale) {
+            // Ignore reference language
+            continue;
+        }
+        if (! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
+            // If the .lang file does not exist, just skip the locale for this file
+            continue;
+        }
+
+        // Read locale data
+        $locale_analysis = LangManager::analyzeLangFile($current_website, $current_locale, $current_filename, $reference_data);
+        $locale_data = LangManager::loadSource($current_website, $current_locale, $current_filename);
+
+        $todo = count($locale_analysis['Identical']) + count($locale_analysis['Missing']);
+        $total = $todo + count($locale_analysis['Translated']);
+
+        $cssclass = ($todo/$total>0.60) ? ' lightlink' : '';
+        $color = 'rgba(255, 0, 0, ' . $todo/$total . ')';
+
+        if ($todo == 0) {
+            $complete_locales_count++;
+            $complete_locales_list[] = $current_locale;
+        }
+
+        echo "    <tr>\n";
+        echo "      <td class='linklocale{$cssclass}' style='background-color: {$color}'>\n";
+        echo "        <a href='./?locale={$current_locale}#{$current_filename}'>{$current_locale}</a>\n";
+        echo "      </td>\n";
+
+        $keys = ['Identical', 'Translated', 'Missing', 'Obsolete'];
+        foreach ($keys as $key) {
+            $counter = count($locale_analysis[$key])
+                       ? count($locale_analysis[$key])
+                       : '';
+            echo "      <td>{$counter}</td>\n";
+            $json_data[$current_filename][$current_locale][$key] = intval($counter);
+        }
+
+        // Tags
+        if (isset($locale_data['tags'])) {
+            $locale_tags = $locale_data['tags'];
+            sort($locale_tags);
+            $json_data[$current_filename][$current_locale]['tags'] = $locale_tags;
+            // Remove _promo from tags
+            $locale_tags = array_map(
+                function($element) {
+                    return str_replace('promo_', '', $element);
+                },
+                $locale_tags
+            );
+            echo "      <td class='tags_column'>" . implode('<br>', $locale_tags) ."</td>\n";
+        } else {
+            echo "      <td></td>\n";
+            $json_data[$current_filename][$current_locale]['tags'] = [];
+        }
+
+        // Activation status
+        $active = $locale_analysis['activated'];
+        $json_data[$current_filename][$current_locale]['activated'] = $active;
+        if ($active) {
+            echo "      <td class='activated'>active</td>\n";
+        } else {
+            echo "      <td></td>\n";
+        }
+        echo "    </tr>\n";
     }
-    if (! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
-        // If the .lang file does not exist, just skip the locale for this file
-        continue;
+
+    $coverage = Project::getUserBaseCoverage($complete_locales_list, $adu) . '%';
+
+    echo '
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan= "7">'
+            . $complete_locales_count
+            . ' perfect locales ('
+            . round($complete_locales_count/count($supported_locales)*100)
+            . '%)<br>'
+            . $coverage
+            . ' of our l10n user base'
+            . '</td>
+        </tr>
+      </tfoot>
+    </table>
+    ';
+} else {
+    // Websites using raw files
+    echo '
+    <table class="sortable rawfiles">
+      <caption class="filename">' . basename($current_filename) . '</caption>
+      <thead>
+        <tr>
+          <th>Locale</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+    ';
+
+    $complete_locales_count = 0;
+    $complete_locales_list = [];
+
+    $supported_locales = Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets);
+    foreach ($supported_locales as $current_locale) {
+        if ($current_locale == $reference_locale) {
+            // Ignore reference language
+            continue;
+        }
+        if (! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
+            // If the raw file does not exist, just skip the locale for this file
+            continue;
+        }
+
+        $file_analysis = RawManager::compareRawFiles($current_website, $current_locale, $current_filename);
+        $cmp_result = $file_analysis['cmp_result'];
+        if ($cmp_result == 'ok') {
+            $complete_locales_count++;
+            $complete_locales_list[] = $current_locale;
+        }
+
+        $json_data[$current_filename][$current_locale]['status'] = $cmp_result;
+
+        $website_name = Project::getWebsiteName($current_website);
+        $locale_link = "<a href='./?locale={$current_locale}#{$website_name}'>{$current_locale}</a>";
+
+        echo "
+        <tr>
+          <td class='maincolumn'>{$locale_link}</td>
+          <td><span class='rawstatus {$cmp_result}'>" . str_replace('_', ' ', $cmp_result) . "</span></td>
+        </tr>\n";
     }
 
-    // Read locale data
-    $locale_analysis = LangManager::analyzeLangFile($current_website, $current_locale, $current_filename, $reference_data);
-    $locale_data = LangManager::loadSource($current_website, $current_locale, $current_filename);
-
-    $todo = count($locale_analysis['Identical']) + count($locale_analysis['Missing']);
-    $total = $todo + count($locale_analysis['Translated']);
-
-    $cssclass = ($todo/$total>0.60) ? ' lightlink' : '';
-    $color = 'rgba(255, 0, 0, ' . $todo/$total . ')';
-
-    if ($todo == 0) {
-        $complete_locales_count++;
-        $complete_locales_list[] = $current_locale;
-    }
-
-    echo "    <tr>\n";
-    echo "      <td class='linklocale{$cssclass}' style='background-color: {$color}'>\n";
-    echo "        <a href='./?locale={$current_locale}#{$current_filename}'>{$current_locale}</a>\n";
-    echo "      </td>\n";
-
-    $keys = ['Identical', 'Translated', 'Missing', 'Obsolete'];
-    foreach ($keys as $key) {
-        $counter = count($locale_analysis[$key])
-                   ? count($locale_analysis[$key])
-                   : '';
-        echo "      <td>{$counter}</td>\n";
-        $json_data[$current_filename][$current_locale][$key] = intval($counter);
-    }
-
-    // Tags
-    if (isset($locale_data['tags'])) {
-        $locale_tags = $locale_data['tags'];
-        sort($locale_tags);
-        $json_data[$current_filename][$current_locale]['tags'] = $locale_tags;
-        // Remove _promo from tags
-        $locale_tags = array_map(
-            function($element) {
-                return str_replace('promo_', '', $element);
-            },
-            $locale_tags
-        );
-        echo "      <td class='tags_column'>" . implode('<br>', $locale_tags) ."</td>\n";
-    } else {
-        echo "      <td></td>\n";
-        $json_data[$current_filename][$current_locale]['tags'] = [];
-    }
-
-    // Activation status
-    $active = $locale_analysis['activated'];
-    $json_data[$current_filename][$current_locale]['activated'] = $active;
-    if ($active) {
-        echo "      <td class='activated'>active</td>\n";
-    } else {
-        echo "      <td></td>\n";
-    }
-    echo "    </tr>\n";
+    $coverage = Project::getUserBaseCoverage($complete_locales_list, $adu) . '%';
+    echo '
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan= "2">'
+            . $complete_locales_count
+            . ' translated locales ('
+            . round($complete_locales_count/count($supported_locales)*100)
+            . '%)<br>'
+            . $coverage
+            . ' of our l10n user base'
+            . '</td>
+        </tr>
+      </tfoot>
+    </table>
+    ';
 }
-
-$coverage = Project::getUserBaseCoverage($complete_locales_list, $adu) . '%';
-
-echo '
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan= "7">'
-        . $complete_locales_count
-        . ' perfect locales ('
-        . round($complete_locales_count/count($supported_locales)*100)
-        . '%)<br>'
-        . $coverage
-        . ' of our l10n user base'
-        . '</td>
-    </tr>
-  </tfoot>
-</table>
-';
 
 $htmlresult = ob_get_contents();
 ob_clean();
@@ -162,5 +231,3 @@ if ($json) {
 } else {
     echo $htmlresult;
 }
-
-

--- a/views/json.inc.php
+++ b/views/json.inc.php
@@ -11,7 +11,7 @@ $string_id = isset($_GET['stringid']) ? Utils::secureText($_GET['stringid']) : f
 
 $supported_file = false;
 // Search which website has the requested file
-foreach ($sites as $site) {
+foreach (Project::getWebsitesByDataType($sites, 'lang') as $site) {
     if (in_array($current_filename, Project::getWebsiteFiles($site))) {
         $current_website = $site;
         $supported_file = true;

--- a/views/listlocalesforproject.inc.php
+++ b/views/listlocalesforproject.inc.php
@@ -4,9 +4,10 @@ namespace Langchecker;
 use \Transvision\Json;
 
 $output_array = [];
+$lang_based_sites = Project::getWebsitesByDataType($sites, 'lang');
 if ($website != '' && $filename != '') {
-    if (isset($sites[$website])) {
-        $current_website = $sites[$website];
+    if (isset($lang_based_sites[$website])) {
+        $current_website = $lang_based_sites[$website];
         $current_filename = $filename;
         if (in_array($current_filename, Project::getWebsiteFiles($current_website))) {
             $output_array = array_values(Project::getSupportedLocales($current_website, $current_filename, $langfiles_subsets));

--- a/views/listpages.inc.php
+++ b/views/listpages.inc.php
@@ -16,22 +16,32 @@ if ($website != '' && isset($sites[$website])) {
 
 foreach ($displayed_sites as $site_index => $current_website) {
     $websitename = Project::getWebsiteName($current_website);
+    $website_data_source = Project::getWebsiteDataType($current_website);
+
+    if ($website_data_source == 'lang') {
+        $table_headers = "<th>Filename</th><th>Status</th><th>Translate</th>";
+    } else {
+        $table_headers = "<th>Filename</th>\n<th>Status</th>\n\n";
+    }
     $htmloutput .= "\n\t<h2 id='{$websitename}'><a href='#{$websitename}'>{$websitename}</a></h2>\n";
     $htmloutput .= "\t<table class='listpages'>
         <thead>
-            <tr>
-                <th>Filename</th>
-                <th>Status</th>
-                <th>Translate</th>
-            </tr>
+            <tr>{$table_headers}</tr>
         </thead>
         <tbody>\n";
     foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
-        $htmloutput .= "\t\t<tr>
-            <td>{$current_filename}</td>
-            <td><a href='?locale=all&amp;website={$site_index}&amp;file={$current_filename}'>Status</a></td>
-            <td><a href='?website={$site_index}&amp;file={$current_filename}&amp;action=translate&amp;show'>Translate</a></td>
-        </tr>\n";
+        if ($website_data_source == 'lang') {
+            $htmloutput .= "<tr>\n" .
+                           "  <td>{$current_filename}</td>\n" .
+                           "  <td><a href='?locale=all&amp;website={$site_index}&amp;file={$current_filename}'>Status</a></td>\n" .
+                           "  <td><a href='?website={$site_index}&amp;file={$current_filename}&amp;action=translate&amp;show'>Translate</a></td>\n" .
+                           "</tr>\n";
+        } else {
+            $htmloutput .= "<tr>\n" .
+                           "  <td>" . basename($current_filename) . "</td>\n" .
+                           "  <td><a href='?locale=all&amp;website={$site_index}&amp;file={$current_filename}'>Status</a></td>\n" .
+                           "</tr>\n";
+        }
     }
     $htmloutput .= "    </tbody>\n</table>\n\n";
 }

--- a/views/translatestrings.inc.php
+++ b/views/translatestrings.inc.php
@@ -21,7 +21,7 @@ $show_status = isset($_GET['show']) ? 'auto' : 'none';
 
 $supported_file = false;
 // Search which website has the requested file
-foreach ($sites as $site) {
+foreach (Project::getWebsitesByDataType($sites, 'lang') as $site) {
     if (in_array($current_filename, Project::getWebsiteFiles($site))) {
         $current_website = $site;
         $supported_file = true;


### PR DESCRIPTION
## Classes

New methods in Project:
- getWebsitesByDataType: retrieve only websites with a specific data type
- getWebsiteDataType: retrieve a website's data type

New class RawManager:
- compareRawFiles: used to compare 2 raw files, return array of results based on hash and date comparisons

Added tests for new methods and class.
## Views

Errors:
- Display an error in locales for missing files only if the don't have the 'optional' flag.
- Display an error for missing reference files.

Export:
- Add 'status' attribute to JSON for raw files instead of identical, missing, etc.. Possible values: untranslated, outdated, ok, missing_reference, missing_locale.
- Add 'data_source' attribute for all files (possible values: 'lang', 'raw').

Globalstatus:
- Display a different table for raw files, with only a status link.

Listpages:
- Display only status link for raw files.

Listsitesforlocale:
- Add table to display raw files status.

All other views remain available only for .lang files.
