### PR TITLE
Catch more variables errors

### DIFF
--- a/tests/testfiles/dotlang/en-US/page.lang
+++ b/tests/testfiles/dotlang/en-US/page.lang
@@ -57,3 +57,11 @@ Third string with %s tags
 
 ;Fourth string with 90%% coverage
 Fourth string with 90%% coverage
+
+
+;Fifth string with %(one)s, %(two)s
+Fifth string with %(one)s, %(two)s
+
+
+;Sixth string with %(one)s
+Sixth string with %(one)s

--- a/tests/testfiles/dotlang/it/page.lang
+++ b/tests/testfiles/dotlang/it/page.lang
@@ -51,3 +51,11 @@ Terza stringa con variabile mancante
 
 ;Fourth string with 90%% coverage
 Quarta stringa con copertura al 90%
+
+
+;Fifth string with %(one)s, %(two)s
+Quinta stringa con %(one)s, %(two)s e ancora %(two)s
+
+
+;Sixth string with %(one)s
+Sesta stringa con %(one)s e %(two)s

--- a/tests/testfiles/dotlang/it/updated_page.lang
+++ b/tests/testfiles/dotlang/it/updated_page.lang
@@ -59,3 +59,11 @@ Terza stringa con variabile mancante
 Quarta stringa con copertura al 90%
 
 
+;Fifth string with %(one)s, %(two)s
+Quinta stringa con %(one)s, %(two)s e ancora %(two)s
+
+
+;Sixth string with %(one)s
+Sesta stringa con %(one)s e %(two)s
+
+

--- a/tests/units/Langchecker/LangManager.php
+++ b/tests/units/Langchecker/LangManager.php
@@ -37,11 +37,11 @@ class LangManager extends atoum\test
 
         $this
             ->integer(count($analysis_data['Translated']))
-                ->isEqualTo(10);
+                ->isEqualTo(12);
 
         $this
             ->integer(count($analysis_data['python_vars']))
-                ->isEqualTo(3);
+                ->isEqualTo(5);
 
         $this
             ->string($analysis_data['python_vars']['String with %(num)s tags']['text'])

--- a/views/errors.inc.php
+++ b/views/errors.inc.php
@@ -59,7 +59,7 @@ foreach ($mozilla as $current_locale) {
                     foreach ($locale_analysis['python_vars'] as $stringid => $python_error) {
                         $locale_htmloutput .= "              <table class='python'>
                 <tr>
-                  <th><strong style='color:red'>{$python_error['var']}</strong> in the English string is missing in:</th>
+                  <th>Check the following variables: <strong style='color:red'>{$python_error['var']}</strong></th>
                 </tr>
                 <tr>
                   <td>" . Utils::highlightPythonVar($stringid) . "</td>

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -141,7 +141,7 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
                 foreach ($locale_analysis['python_vars'] as $stringid => $python_error) {
                     $todo_files .= "              <table class='python'>
                 <tr>
-                  <th><strong style='color:red'>{$python_error['var']}</strong> in the English string is missing in:</th>
+                  <th>Check the following variables: <strong style='color:red'>{$python_error['var']}</strong></th>
                 </tr>
                 <tr>
                   <td>" . Utils::highlightPythonVar($stringid) . "</td>


### PR DESCRIPTION
Display errors:
- When locale has extra variables.
- When a variable is used a different number of times than reference.
