### PR TITLE
CSS: fix one more compatibility linter warning

### DIFF
--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -358,8 +358,9 @@ td.even {
 /* List locales */
 
 ul#locales {
-    -moz-column-count: 6;
     -webkit-column-count: 6;
+    -moz-column-count: 6;
+    column-count: 6;
     width: 80%;
 }
 


### PR DESCRIPTION
Invert order, add unprefixed attribute `column-count`
