### PR TITLE
CSS: clean up linter warnings

### DIFF
--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -47,10 +47,10 @@ body {
     min-width: 800px;
 }
 
-.sand #outer-wrapper {
-    background: #f5f1e8 url(../img/sandstone/bg-sand.png) repeat-x top left;
+#outer-wrapper {
     background: url(../img/sandstone/bg-gradient-sand.png) repeat-x 0 0,
-                url(../img/sandstone/bg-sand.png) repeat 0 0, #f5f1e8;
+                url(../img/sandstone/bg-sand.png) repeat 0 0,
+                #f5f1e8;
     height: 100%;
 }
 
@@ -132,25 +132,25 @@ caption.filename {
     padding: 6px;
 }
 
-tr.dim {
+.count_complete {
     color: #ddd;
 }
 
-td.tags_column {
+.tags_cell {
     text-align: left;
     font-size: 11px;
 }
 
-td.activated {
+.activated_cell {
     background-color: #92cc6e;
     color: #92cc6e;
 }
 
-td.lightlink a {
+.lightlink_cell a {
     color: #c7edff;
 }
 
-td.linklocale a {
+.linklocale_cell a {
     font-weight: bold;
 }
 
@@ -168,14 +168,14 @@ tr.tabletotals th {
 
 /* View: listsitesforlocale */
 
-div.website {
+.website_container {
     border: 1px solid #78756f;
     margin: 0 0 10px 0;
     padding: 0 10px;
     background-color: #faf8f2;
 }
 
-a.filedone {
+.file_done {
     display: inline-block;
     color: #FFF;
     background: #78756f;
@@ -183,26 +183,26 @@ a.filedone {
     margin: 2px;
 }
 
-a.activated {
+.file_activated {
     border-right: 8px solid #92cc6e;
 }
 
-a.notactivated {
+.file_notactivated {
     border-right: 8px solid #ff5252;
 }
 
-a.notutf8:after {
+.file_notutf8:after {
     content: " (Not in UTF-8 !)";
     color: #ffbd52;
     font-weight: bold;
 }
 
-div.filename {
+.file_container {
     background-color: #fff;
     padding: 5px;
 }
 
-div.filename h3.filename {
+.file_container .filename {
     display: inline-block;
     margin: 0 0 10px 0;
     padding: 2px 1em;
@@ -213,15 +213,15 @@ div.filename h3.filename {
     font-size: 120%;
 }
 
-div.filename h3.filename a:link,
-div.filename h3.filename a:visited,
-div.filename h3.filename a:hover,
-div.filename h3.filename a:active
+.file_container .filename a:link,
+.file_container .filename a:visited,
+.file_container .filename a:hover,
+.file_container .filename a:active
 {
     color: #fff;
 }
 
-div.filename table.side {
+.file_container .sidetable {
     float: right;
     margin: 0 0 20px 20px;
 }
@@ -260,7 +260,7 @@ div.tip blockquote {
     color: rgba(80, 80, 80, 1)
 }
 
-span.datasource {
+.datasource {
     font-size: 12px;
     padding: 0.2em 0.4em;
     border-radius: 0.25em;
@@ -313,7 +313,7 @@ span.datasource {
 
 /* List pages */
 
-table.listpages tr td:first-child {
+.listpages tr td:first-child {
     text-align: left;
     min-width: 250px;
     padding: 2px 6px;
@@ -333,7 +333,7 @@ table.listpages tr td:first-child {
     margin: 0 2px;
 }
 
-td.done {
+.donelocales_cell {
     text-align: left;
     font-style: italic;
     color: #808080;
@@ -347,43 +347,44 @@ td.done {
     width: 5em;
 }
 
-td.odd {
+.odd_row {
     background-color: #fff;
 }
 
-td.even {
+.even_row {
     background-color: #faf6ed;
 }
 
 /* List locales */
 
-ul#locales {
-    -webkit-column-count: 6;
+#locales {
     -moz-column-count: 6;
+    -webkit-column-count: 6;
+    -ms-column-count: 6;
     column-count: 6;
     width: 80%;
 }
 
 /* action=count */
 
-table#count_summary {
+#count_summary {
     margin-top: 1em;
 }
 
-table#count_summary th,
-table#count_summary td {
+#count_summary th,
+#count_summary td {
     margin: 0 1em;
 }
 
-table#count_summary td + td {
+#count_summary td + td {
     text-align: left;
     word-spacing: 0.3em;
 }
 
-table#count_summary td:nth-child(3) {
+#count_summary td:nth-child(3) {
     max-width: 30em;
 }
 
-table#count_summary .help {
+#count_summary .help {
     cursor: help;
 }

--- a/templates/template.inc.php
+++ b/templates/template.inc.php
@@ -7,7 +7,7 @@
   <script src="./media/js/sorttable.js"></script>
   <link href="./media/css/langchecker.css" rel="stylesheet">
 </head>
-<body class="sand">
+<body>
 <?php echo "<!-- Current view: {$viewname} -->\n"; ?>
 <div id="outer-wrapper">
     <div id="wrapper">

--- a/views/countstrings.inc.php
+++ b/views/countstrings.inc.php
@@ -55,7 +55,7 @@ if ($json) {
 $rows = '';
 foreach ($todo as $key => $val) {
     if ($val == 0) {
-        $class = 'class="dim"';
+        $class = 'class="count_complete"';
     } else {
         $class = '';
     }

--- a/views/errors.inc.php
+++ b/views/errors.inc.php
@@ -17,7 +17,7 @@ foreach ($mozilla as $current_locale) {
         if (Project::isSupportedLocale($current_website, $current_locale)) {
             $repo = Project::getPublicRepoPath($current_website, $current_locale);
             $current_website_name = Project::getWebsiteName($current_website);
-            $opening_div = "      <div class='website'>\n" .
+            $opening_div = "      <div class='website_container'>\n" .
                            "        <h2>{$current_website_name}</h2>\n";
 
             foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
@@ -51,7 +51,7 @@ foreach ($mozilla as $current_locale) {
                         $locale_htmloutput .= $opening_div;
                     }
                     $locale_htmloutput .= "        <p>Repository: <a href='{$repo}'>{$repo}</a></p>\n";
-                    $locale_htmloutput .= "        <div class='filename' id='{$current_filename}'>\n";
+                    $locale_htmloutput .= "        <div class='file_container' id='{$current_filename}'>\n";
                     $locale_htmloutput .= "          <h3 class='filename'><a href='#{$current_filename}'>{$current_filename}</a></h3>\n";
 
                     $locale_htmloutput .= "          <h3>Errors in variables in the sentence:</h3>\n";
@@ -174,7 +174,7 @@ foreach ($mozilla as $current_locale) {
         if (Project::isSupportedLocale($current_website, $current_locale)) {
             $repo = Project::getPublicRepoPath($current_website, $current_locale);
             $current_website_name = Project::getWebsiteName($current_website);
-            $opening_div = "      <div class='website'>\n" .
+            $opening_div = "      <div class='website_container'>\n" .
                            "        <h2>{$current_website_name}</h2>\n";
 
             foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
@@ -217,7 +217,7 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
     $reference_locale = Project::getReferenceLocale($current_website);
 
     $reference_output = "      <h2>Reference locale: {$reference_locale}</h2>\n";
-    $opening_div = "      <div class='website'>\n" .
+    $opening_div = "      <div class='website_container'>\n" .
                    "        <h2>{$current_website_name}</h2>\n";
 
     foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
@@ -250,7 +250,7 @@ foreach (Project::getWebsitesByDataType($sites, 'raw') as $current_website) {
     $reference_locale = Project::getReferenceLocale($current_website);
 
     $reference_output = "      <h2>Reference locale: {$reference_locale}</h2>\n";
-    $opening_div = "      <div class='website'>\n" .
+    $opening_div = "      <div class='website_container'>\n" .
                    "        <h2>{$current_website_name}</h2>\n";
 
     foreach (Project::getWebsiteFiles($current_website) as $current_filename) {

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -78,7 +78,7 @@ if ($website_data_source == 'lang') {
         $todo = count($locale_analysis['Identical']) + count($locale_analysis['Missing']);
         $total = $todo + count($locale_analysis['Translated']);
 
-        $cssclass = ($todo/$total>0.60) ? ' lightlink' : '';
+        $cssclass = ($todo/$total>0.60) ? ' lightlink_cell' : '';
         $color = 'rgba(255, 0, 0, ' . $todo/$total . ')';
 
         if ($todo == 0) {
@@ -87,7 +87,7 @@ if ($website_data_source == 'lang') {
         }
 
         echo "    <tr>\n";
-        echo "      <td class='linklocale{$cssclass}' style='background-color: {$color}'>\n";
+        echo "      <td class='linklocale_cell {$cssclass}' style='background-color: {$color}'>\n";
         echo "        <a href='./?locale={$current_locale}#{$current_filename}'>{$current_locale}</a>\n";
         echo "      </td>\n";
 
@@ -112,7 +112,7 @@ if ($website_data_source == 'lang') {
                 },
                 $locale_tags
             );
-            echo "      <td class='tags_column'>" . implode('<br>', $locale_tags) ."</td>\n";
+            echo "      <td class='tags_cell'>" . implode('<br>', $locale_tags) ."</td>\n";
         } else {
             echo "      <td></td>\n";
             $json_data[$current_filename][$current_locale]['tags'] = [];
@@ -122,7 +122,7 @@ if ($website_data_source == 'lang') {
         $active = $locale_analysis['activated'];
         $json_data[$current_filename][$current_locale]['activated'] = $active;
         if ($active) {
-            echo "      <td class='activated'>active</td>\n";
+            echo "      <td class='activated_cell'>active</td>\n";
             $activated_locales_count++;
             $activated_locales_list[] = $current_locale;
         } else {

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -16,7 +16,7 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
     $repo = Project::getPublicRepoPath($current_website, $current_locale);
     $website_name = Project::getWebsiteName($current_website);
 
-    $html_output .= "\n<div class='website'>\n";
+    $html_output .= "\n<div class='website_container'>\n";
     $html_output .= "  <h2 id='{$website_name}'><a href='#{$website_name}'>{$website_name}</a><span class='datasource'>lang</span></h2>\n";
     $html_output .= "  <p>Repository: <a href='{$repo}'>{$repo}</a></p>\n";
 
@@ -65,14 +65,14 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
 
         if (! in_array($current_filename, $no_active_tag) &&
             $website_name == 'www.mozilla.org') {
-            $status = $locale_analysis['activated'] ? ' activated' : ' notactivated';
+            $status = $locale_analysis['activated'] ? ' file_activated' : ' file_notactivated';
         } else {
-            $status = ' activated';
+            $status = ' file_activated';
         }
 
         // check if the lang file is in utf8
         if (Utils::isUTF8($locale_filename) == false) {
-            $status .= ' notutf8';
+            $status .= ' file_notutf8';
         }
 
         $count_identical = count($locale_analysis['Identical']);
@@ -81,11 +81,11 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
 
         if ($count_identical + $count_missing + $count_errors == 0) {
             // File is complete
-            $done_files .= "  <a href='#{$current_filename}' class='filedone{$status}'>{$current_filename}</a>\n";
+            $done_files .= "  <a href='#{$current_filename}' class='file_done{$status}'>{$current_filename}</a>\n";
         } else {
-            $todo_files .= "  <div class='filename' id='{$current_filename}'>\n" .
+            $todo_files .= "  <div class='file_container' id='{$current_filename}'>\n" .
                            "    <h3 class='filename'><a href='#{$current_filename}'>{$current_filename}</a></h3>\n" .
-                           "    <table class='side'>\n" .
+                           "    <table class='sidetable'>\n" .
                            "      <thead>\n" .
                            "        <tr>\n" .
                            "          <th>Identical</th>\n" .
@@ -181,7 +181,7 @@ foreach (Project::getWebsitesByDataType($sites, 'raw') as $current_website) {
     $repo = Project::getPublicRepoPath($current_website, $current_locale);
     $website_name = Project::getWebsiteName($current_website);
 
-    $html_output .= "\n<div class='website'>\n";
+    $html_output .= "\n<div class='website_container'>\n";
     $html_output .= "  <h2 id='{$website_name}'><a href='#{$website_name}'>{$website_name}</a><span class='datasource'>raw</span></h2>\n";
     $html_output .= "  <p>Repository: <a href='{$repo}'>{$repo}</a></p>\n";
 
@@ -198,7 +198,7 @@ foreach (Project::getWebsitesByDataType($sites, 'raw') as $current_website) {
 
         if ($cmp_result == 'ok') {
             // File is translated, store it for later and move on to the next file
-            $done_files .=   "<a class='filedone activated'>" . basename($current_filename) . "</a>\n";
+            $done_files .=   "<a class='file_done activated'>" . basename($current_filename) . "</a>\n";
             continue;
         }
 

--- a/views/translatestrings.inc.php
+++ b/views/translatestrings.inc.php
@@ -103,7 +103,7 @@ foreach ($all_strings as $string_id => $available_translations) {
 
     $displayed_rows = 0;
     foreach ($available_translations as $current_locale => $translation) {
-        $css_class = ($displayed_rows & 1) ? 'odd' : 'even';
+        $css_class = ($displayed_rows & 1) ? 'odd_row' : 'even_row';
         echo "<tr class='{$css_class}'>\n"
              . "  <th>{$current_locale}</th>\n"
              . "  <td>" . htmlspecialchars($translation) . "</td>\n"
@@ -111,7 +111,7 @@ foreach ($all_strings as $string_id => $available_translations) {
         $displayed_rows++;
     }
 
-    echo "<tr>\n  <td colspan='2' class='done'>Number of locales done: {$total_translations}"
+    echo "<tr>\n  <td colspan='2' class='donelocales_cell'>Number of locales done: {$total_translations}"
         . ' (' . Project::getUserBaseCoverage($covered_locales, $adu) . '% of our l10n user base)'
         . "  </td>\n</tr>\n</table>\n";
 


### PR DESCRIPTION
I've been playing with [Codacy](https://www.codacy.com/public/flod/langchecker/dashboard?bid=1991368), and tried to clean-up the performance section. 
Mostly removing over-qualified rules, and giving elements better names.
