### PR TITLE
Add check for max length of strings, reduce classes size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/settings.inc.php
+composer.phar
 composer.lock
 locales
 vendor/

--- a/classes/Langchecker/DotLangParser.php
+++ b/classes/Langchecker/DotLangParser.php
@@ -1,7 +1,7 @@
 <?php
 namespace Langchecker;
 
-/*
+/**
  * DotLangParser class
  *
  * This class is for all the methods we use to read .lang files
@@ -11,12 +11,15 @@ namespace Langchecker;
  */
 class DotLangParser
 {
-    /*
+    /**
      * Load file, remove empty lines and return an array of strings
      *
-     * @param   string          $path         Filename to analyze
-     * @param   boolean         $show_errors  Display or not errors in case of missing file
-     * @return  array/boolean                 Cleaned up array of lines, or false if file is missing
+     * @param   string   $path         Filename to analyze
+     * @param   boolean  $show_errors  Display or not errors in case of
+     *                                 missing file
+     *
+     * @return  mixed                  Cleaned up array of lines (array),
+     *                                 or false if file is missing
      */
     public static function getFile($path, $show_errors = true)
     {
@@ -36,11 +39,13 @@ class DotLangParser
         return $file_content;
     }
 
-    /*
+    /**
      * Read file of strings and return an array with all relevant data.
      *
      * @param   string   $path              Full path to filename to analyze
-     * @param   boolean  $reference_locale  If I'm currently analyzing the reference locale
+     * @param   boolean  $reference_locale  If I'm currently analyzing the
+     *                                      reference locale
+     *
      * @return  array                       Extracted data
      */
     public static function parseFile($path, $reference_locale = false)
@@ -70,8 +75,7 @@ class DotLangParser
 
                 // Other tags like ## promo_news ##, but not meta data
                 if (Utils::startsWith($current_line, '##') &&
-                    ! Utils::startsWith($current_line, '## NOTE:') &&
-                    ! Utils::startsWith($current_line, '## TAG:')) {
+                    ! Utils::startsWith($current_line, ['## NOTE:', '## TAG:', '## MAX_LENGTH:'])) {
                     $dotlang_data['tags'][] = trim(str_replace('##', '', $current_line));
                     continue;
                 }
@@ -96,7 +100,7 @@ class DotLangParser
                         $dotlang_data['duplicates'][] = $reference;
                     }
 
-                    if (Utils::startsWith($translation, ';') || Utils::startsWith($translation, '#')) {
+                    if (Utils::startsWith($translation, [';', '#'])) {
                         /* Empty translation: what I'm reading as translation is either the next reference string
                          * or the next meta tag (comment, tag binding). I consider this string untranslated.
                          */
@@ -123,14 +127,19 @@ class DotLangParser
                             if (! Utils::startsWith($file_content[$j], '#')) {
                                 break;
                             }
-                            // Tag bindings
-                            if (Utils::startsWith($file_content[$j], '## TAG:')) {
-                                $dotlang_data['tag_bindings'][$reference] = Utils::leftStrip($file_content[$j], '## TAG:');
-                            }
                             // Comments
                             if (Utils::startsWith($file_content[$j], '#') &&
                                 ! Utils::startsWith($file_content[$j], '##')) {
                                 $dotlang_data['comments'][$reference][] = Utils::leftStrip($file_content[$j], '#');
+                            } else {
+                                // Tag bindings
+                                if (Utils::startsWith($file_content[$j], '## TAG:')) {
+                                    $dotlang_data['tag_bindings'][$reference] = Utils::leftStrip($file_content[$j], '## TAG:');
+                                }
+                                // Length limits
+                                if (Utils::startsWith($file_content[$j], '## MAX_LENGTH:')) {
+                                    $dotlang_data['max_lengths'][$reference] = intval(Utils::leftStrip($file_content[$j], '## MAX_LENGTH:'));
+                                }
                             }
                             $j--;
                         }

--- a/classes/Langchecker/GetTextManager.php
+++ b/classes/Langchecker/GetTextManager.php
@@ -1,0 +1,185 @@
+<?php
+namespace Langchecker;
+
+/**
+ * GetTextManager class
+ *
+ * This class is used to read reference and localized files in GetText format
+ *
+ *
+ * @package Langchecker
+ */
+class GetTextManager
+{
+    /**
+     * Read .po file and return array of translated (not fuzzy)
+     * strings [original]=>translation
+     *
+     * @param   string  $path  Path to the file to read
+     *
+     * @return  array          Array of strings
+     */
+    public static function loadPoFile($path)
+    {
+        $po_parser = new \Sepia\PoParser();
+        $po_strings = $po_parser->read($path);
+
+        $po_data = [];
+        if (count($po_strings) > 0) {
+            foreach ($po_strings as $entry) {
+                if (!isset($entry['fuzzy']) && implode($entry['msgstr']) != '') {
+                    if (implode($entry['msgid']) == implode($entry['msgstr'])) {
+                        // Add {ok} if the translation is identical to the English string
+                        $string_status = ' {ok}';
+                    } else {
+                        $string_status = '';
+                    }
+                    $po_data[implode($entry['msgid'])] = trim(implode($entry['msgstr']) . $string_status);
+                }
+            }
+        }
+
+        return $po_data;
+    }
+
+    /**
+     * Read .po file from Locamotion's github repository, return updated strings
+     *
+     * @param   array    $locale_data       Array of data for locale file
+     * @param   string   $current_filename  Analyzed file
+     * @param   string   $current_locale    Requested locale
+     * @param   string   $lomocation_repo   Path to local clone of Locamotion's repository
+     *
+     * @return  array                       Result of import (boolean), errors (array),
+     *                                      updated strings (array)
+     */
+    public static function importLocamotion($locale_data, $current_filename, $current_locale, $locamotion_repo)
+    {
+        $result = [
+          'imported' => false,
+          'errors'   => [],
+          'strings'  => []
+        ];
+
+        Utils::logger("== {$current_locale} ==");
+
+        $local_import = $locamotion_repo != '' ? true : false;
+
+        if ($local_import) {
+            // Import from local clone
+            $file_path = $locamotion_repo .
+                         str_replace('-', '_', $current_locale)
+                         . '/' . $current_filename . '.po';
+            $po_exists = file_exists($file_path);
+        } else {
+            // Import data from remote
+            $locamotion_url = 'https://raw.githubusercontent.com/translate/mozilla-lang/master/'
+                              . str_replace('-', '_', $current_locale)
+                              . '/' . $current_filename . '.po';
+            $http_response = get_headers($locamotion_url, 1)[0];
+            $po_exists = strstr($http_response, '200') ? true : false;
+        }
+
+        if ($po_exists) {
+            if ($local_import) {
+                $po_strings = self::loadPoFile($file_path);
+            } else {
+                Utils::logger("Fetching {$current_filename} from Locamotion.");
+                // Create temporary file (temp.po), delete it after extracting strings
+                file_put_contents('temp.po', file_get_contents($locamotion_url));
+                $po_strings = self::loadPoFile('temp.po');
+                unlink('temp.po');
+            }
+
+            if (count($po_strings) == 0) {
+                Utils::logger('.po file is empty.');
+            } else {
+                foreach ($po_strings as $string_id => $translation) {
+                    if (isset($locale_data['strings'][$string_id])) {
+                        // String is available in the local lang file, check if is different
+                        if (Utils::startsWith($po_strings[$string_id], ';')) {
+                            // Translations can't start with ";"
+                            $result['errors'][] = "({$current_locale} - {$current_filename}): translation starts with ;\n{$po_strings[$string_id]}";
+                        } elseif ($po_strings[$string_id] !== $locale_data['strings'][$string_id]) {
+                            // Translation in the .po file is different
+                            Utils::logger("Updated translation: {$string_id} => {$translation}");
+                            $locale_data['strings'][$string_id] = $translation;
+                            $result['imported'] = true;
+                        }
+                    }
+                }
+                $result['strings'] = $locale_data['strings'];
+            }
+        } else {
+            if ($local_import) {
+                Utils::logger("{$file_path} does not exist.");
+            } else {
+                Utils::logger("{$locamotion_url} does not exist, http code was {$http_response}");
+            }
+
+            return $result;
+        }
+
+        if ($result['imported']) {
+            Utils::logger('Locamotion data extracted and added to local repository.');
+        } else {
+            Utils::logger('No new strings from Locamotion added to local repository.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Read local .po file, return updated strings
+     *
+     * @param   string   $po_filename     Path to po file
+     * @param   array    $locale_data     Array of data for locale file
+     * @param   boolean  $output_message  True (default) to output messages in console
+     *
+     * @return  array                     Result of import (boolean), errors (array),
+     *                                    updated strings (array)
+     */
+    public static function importLocalPoFile($po_filename, $locale_data, $output_message = true)
+    {
+        $result = [
+          'imported' => false,
+          'errors'   => [],
+          'strings'  => []
+        ];
+
+        // Read po file
+        $po_strings = self::loadPoFile($po_filename);
+
+        if (count($po_strings) == 0 && $output_message) {
+            Utils::logger('.po file is empty.');
+        } else {
+            foreach ($po_strings as $string_id => $translation) {
+                if (isset($locale_data['strings'][$string_id])) {
+                    // String is available in the local lang file, check if is different
+                    if (Utils::startsWith($po_strings[$string_id], ';')) {
+                        // Translations can't start with ";"
+                        $result['errors'][] = "Translation starts with ;\n{$po_strings[$string_id]}";
+                    } elseif ($po_strings[$string_id] !== $locale_data['strings'][$string_id]) {
+                        // Translation in the .po file is different
+                        if ($output_message) {
+                            Utils::logger("Updated translation: {$string_id} => {$translation}");
+                        }
+                        $locale_data['strings'][$string_id] = $translation;
+                        $result['imported'] = true;
+                    }
+                }
+            }
+            $result['strings'] = $locale_data['strings'];
+        }
+
+        if ($output_message) {
+            if ($result['imported']) {
+                Utils::logger('Data imported.');
+            } else {
+                Utils::logger('No data imported.');
+            }
+        }
+
+        return $result;
+    }
+}

--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -1,21 +1,23 @@
 <?php
 namespace Langchecker;
 
-/*
+/**
  * LangManager class
  *
- * This class is used to read reference and localized files
+ * This class is used to read reference and localized files in .lang file format
+ *
  *
  * @package Langchecker
  */
 class LangManager
 {
-    /*
+    /**
      * Load file, remove empty lines and return an array of strings
      *
      * @param   array   $website   Website data
      * @param   string  $locale    Locale to analyze
      * @param   string  $filename  File to analyze
+     *
      * @return  array              Data parsed from lang file
      */
     public static function loadSource($website, $locale, $filename)
@@ -26,95 +28,158 @@ class LangManager
         return DotLangParser::parseFile($path, $is_reference_language);
     }
 
-    /*
+    /**
+     * Check string for Python errors
+     *
+     * @param   string  $reference    Reference string
+     * @param   string  $translation  Translation
+     * @param   string  $errors       Current errors
+     *
+     * @return  array                 Python errors
+     */
+    public static function checkPythonErrors($reference, $translation, $errors) {
+        /* Test if all Python variables are present, analyzing both
+         * format %(var)s or %s, or 'escaped' percentage sign (%%) */
+        $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
+        preg_match_all($regex, $reference, $matches_reference);
+        preg_match_all($regex, $translation, $matches_locale);
+
+        if ($matches_reference[0] != $matches_locale[0]) {
+            /* Locale and reference have different variables. Count
+             * instances of each variable and compare them. */
+            $count_occurences = function ($value, $array) {
+                // Count occurences of $value in $array
+                $count_values = array_count_values($array);
+                $occurences = isset($count_values[$value]) ?
+                              $count_values[$value] :
+                              0;
+
+                return $occurences;
+            };
+
+            foreach ($matches_reference[0] as $python_var) {
+                if ($count_occurences($python_var, $matches_locale[0]) != $count_occurences($python_var, $matches_reference[0])) {
+                    $errors[$reference] =[
+                        'text' => $translation,
+                        'var'  => $python_var
+                    ];
+                }
+            }
+
+            // Check if locale has extra variables
+            foreach ($matches_locale[0] as $python_var) {
+                if (! in_array($python_var, $matches_reference[0])) {
+                    $errors[$reference] =[
+                        'text' => $translation,
+                        'var'  => $python_var
+                    ];
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Check string for length errors
+     *
+     * @param   string   $reference    Reference string
+     * @param   string   $translation  Translation
+     * @param   integer  $limit        Max length for this string
+     * @param   string   $errors       Current errors
+     *
+     * @return  array                  Length errors
+     */
+    public static function checkLengthErrors($reference, $translation, $limit, $errors) {
+        $str_length = Utils::getLength($translation);
+        if ($str_length > $limit) {
+            $errors[$reference] = [
+                'current' => $str_length,
+                'limit'   => $limit,
+                'text'    => $translation,
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
      * Load file, remove empty lines and return an array of strings
      *
      * @param   array   $website         Website data
      * @param   string  $locale          Locale to analyze
      * @param   string  $filename        File to analyze
      * @param   array   $reference_data  Array with data from reference locale
+     *
      * @return  array                    Analysis data
      */
     public static function analyzeLangFile($website, $locale, $filename, $reference_data)
     {
         $locale_data = self::loadSource($website, $locale, $filename);
+        $analysis_data = [
+            'activated'  => $locale_data['activated'],
+            'Identical'  => [],
+            'Translated' => [],
+            'Missing'    => [],
+            'Obsolete'   => [],
+            'errors'     => [
+                'python' => [],
+                'length' => [],
+            ],
+        ];
 
-        $analysis_data['Identical']   = [];
-        $analysis_data['Translated']  = [];
-        $analysis_data['Missing']     = [];
-        $analysis_data['Obsolete']    = [];
-        $analysis_data['python_vars'] = [];
-        $analysis_data['activated'] = $locale_data['activated'];
-
-        foreach ($locale_data['strings'] as $key => $val) {
-            if (isset($reference_data['strings'][$key])) {
-                if ($val === $reference_data['strings'][$key]) {
+        foreach ($locale_data['strings'] as $reference => $translation) {
+            if (isset($reference_data['strings'][$reference])) {
+                if ($translation === $reference_data['strings'][$reference]) {
                     // Store as identical string
-                    $analysis_data['Identical'][] = $key;
-                } elseif ($val !== $reference_data['strings'][$key]) {
+                    $analysis_data['Identical'][] = $reference;
+                } elseif ($translation !== $reference_data['strings'][$reference]) {
                     // Store in translated strings
-                    $analysis_data['Translated'][] = $key;
+                    $analysis_data['Translated'][] = $reference;
 
-                    /* Test if all Python variables are present, analyzing both
-                     * format %(var)s or %s, or 'escaped' percentage sign (%%) */
-                    $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
-                    preg_match_all($regex, $reference_data['strings'][$key], $matches_reference);
-                    preg_match_all($regex, $val, $matches_locale);
+                    // Search for Python errors
+                    $analysis_data['errors']['python'] = self::checkPythonErrors(
+                        $reference,
+                        $translation,
+                        $analysis_data['errors']['python']
+                    );
 
-                    if ($matches_reference[0] != $matches_locale[0]) {
-                        /* Locale and reference have different variables. Count
-                         * instances of each variable and compare them. */
-                        $count_occurences = function ($value, $array) {
-                            // Count occurences of $value in $array
-                            $count_values = array_count_values($array);
-                            $occurences = isset($count_values[$value]) ?
-                                          $count_values[$value] :
-                                          0;
-
-                            return $occurences;
-                        };
-
-                        foreach ($matches_reference[0] as $python_var) {
-                            if ($count_occurences($python_var, $matches_locale[0]) != $count_occurences($python_var, $matches_reference[0])) {
-                                $analysis_data['python_vars'][$key]['text'] = $val;
-                                $analysis_data['python_vars'][$key]['var'] = $python_var;
-                            }
-                        }
-
-                        // Check if locale has extra variables
-                        foreach ($matches_locale[0] as $python_var) {
-                            if (! in_array($python_var, $matches_reference[0])) {
-                                $analysis_data['python_vars'][$key]['text'] = $val;
-                                $analysis_data['python_vars'][$key]['var'] = $python_var;
-                            }
-                        }
+                    if (isset($reference_data['max_lengths'][$reference])) {
+                        // Search for strings too long
+                        $analysis_data['errors']['length'] = self::checkLengthErrors(
+                            $reference,
+                            $translation,
+                            $reference_data['max_lengths'][$reference],
+                            $analysis_data['errors']['length']
+                        );
                     }
-                } elseif ($val === '') {
+                } elseif ($translation === '') {
                     // Store in missing strings
-                    $analysis_data['Missing'][] = $key;
+                    $analysis_data['Missing'][] = $reference;
                 }
             } else {
                 // Store in obsolete strings
-                $analysis_data['Obsolete'][] = $key;
+                $analysis_data['Obsolete'][] = $reference;
             }
         }
 
         // Use reference to determine missing strings
-        foreach ($reference_data['strings'] as $key => $val) {
-            if (! isset($locale_data['strings'][$key])) {
-                $analysis_data['Missing'][] = $key;
+        foreach ($reference_data['strings'] as $reference => $translation) {
+            if (! isset($locale_data['strings'][$reference])) {
+                $analysis_data['Missing'][] = $reference;
             }
         }
 
         return $analysis_data;
     }
 
-    /*
+    /**
      * Check if a string is localized
      *
      * @param   string   $string_id       String id to check
      * @param   array    $locale_data     Array with data for locale
      * @param   array    $reference_data  Array with data for reference locale
+     *
      * @return  boolean                   True if string is localized
      */
     public static function isStringLocalized($string_id, $locale_data, $reference_data)
@@ -129,13 +194,14 @@ class LangManager
         return false;
     }
 
-    /*
+    /**
      * Create lang file content
      *
      * @param   array   $reference_data  Array with data for reference locale
      * @param   array   $locale_data     Array with data for locale
      * @param   string  $current_locale  Requested locale
      * @param   string  $eol             EOL character to use
+     *
      * @return  string                   Lang file content
      */
     public static function buildLangFile($reference_data, $locale_data, $current_locale, $eol)
@@ -213,12 +279,13 @@ class LangManager
         return $content;
     }
 
-    /*
+    /**
      * Manage string exceptions
      *
      * @param   string  $string_id       String we need to manage
      * @param   string  $translation     Current translation
      * @param   string  $current_locale  Requested locale
+     *
      * @return  array                    Modified reference and translated strings
      */
     public static function manageStringExceptions($string_id, $translation, $current_locale)
@@ -242,169 +309,29 @@ class LangManager
         ];
     }
 
-    /*
-     * Read .po file and return array of translated (not fuzzy) strings [original]=>translation
+    /**
+     * Return count of all errors
      *
-     * @param   string  $path  Path to the file to read
-     * @return  array          Array of strings
-     */
-    public static function loadPoFile($path)
-    {
-        $po_parser = new \Sepia\PoParser();
-        $po_strings = $po_parser->read($path);
-
-        $po_data = [];
-        if (count($po_strings) > 0) {
-            foreach ($po_strings as $entry) {
-                if (!isset($entry['fuzzy']) && implode($entry['msgstr']) != '') {
-                    if (implode($entry['msgid']) == implode($entry['msgstr'])) {
-                        // Add {ok} if the translation is identical to the English string
-                        $string_status = ' {ok}';
-                    } else {
-                        $string_status = '';
-                    }
-                    $po_data[implode($entry['msgid'])] = trim(implode($entry['msgstr']) . $string_status);
-                }
-            }
-        }
-
-        return $po_data;
-    }
-
-    /*
-     * Read .po file from Locamotion's github repository, return updated strings
+     * @param   array    $errors      Array of errors generated by analyzeLangFile
+     * @param   array    $error_type  Type of error to count (optional)
      *
-     * @param   array    $locale_data       Array of data for locale file
-     * @param   string   $current_filename  Analyzed file
-     * @param   string   $current_locale    Requested locale
-     * @param   string   $lomocation_repo   Path to local clone of Locamotion's repository
-     * @return  array                       Result of import (boolean), errors (array), updated strings (array)
+     * @return  integer               Count of errors
      */
-    public static function importLocamotion($locale_data, $current_filename, $current_locale, $locamotion_repo)
+    public static function countErrors($errors, $error_type = 'all')
     {
-        $result = [
-          'imported' => false,
-          'errors'   => [],
-          'strings'  => []
-        ];
+        $error_count = 0;
 
-        Utils::logger("== {$current_locale} ==");
-
-        $local_import = $locamotion_repo != '' ? true : false;
-
-        if ($local_import) {
-            // Import from local clone
-            $file_path = $locamotion_repo .
-                         str_replace('-', '_', $current_locale)
-                         . '/' . $current_filename . '.po';
-            $po_exists = file_exists($file_path);
-        } else {
-            // Import data from remote
-            $locamotion_url = 'https://raw.githubusercontent.com/translate/mozilla-lang/master/'
-                              . str_replace('-', '_', $current_locale)
-                              . '/' . $current_filename . '.po';
-            $http_response = get_headers($locamotion_url, 1)[0];
-            $po_exists = strstr($http_response, '200') ? true : false;
-        }
-
-        if ($po_exists) {
-            if ($local_import) {
-                $po_strings = self::loadPoFile($file_path);
-            } else {
-                Utils::logger("Fetching {$current_filename} from Locamotion.");
-                // Create temporary file (temp.po), delete it after extracting strings
-                file_put_contents('temp.po', file_get_contents($locamotion_url));
-                $po_strings = self::loadPoFile('temp.po');
-                unlink('temp.po');
-            }
-
-            if (count($po_strings) == 0) {
-                Utils::logger('.po file is empty.');
-            } else {
-                foreach ($po_strings as $string_id => $translation) {
-                    if (isset($locale_data['strings'][$string_id])) {
-                        // String is available in the local lang file, check if is different
-                        if (Utils::startsWith($po_strings[$string_id], ';')) {
-                            // Translations can't start with ";"
-                            $result['errors'][] = "({$current_locale} - {$current_filename}): translation starts with ;\n{$po_strings[$string_id]}";
-                        } elseif ($po_strings[$string_id] !== $locale_data['strings'][$string_id]) {
-                            // Translation in the .po file is different
-                            Utils::logger("Updated translation: {$string_id} => {$translation}");
-                            $locale_data['strings'][$string_id] = $translation;
-                            $result['imported'] = true;
-                        }
-                    }
-                }
-                $result['strings'] = $locale_data['strings'];
+        if ($error_type == 'all') {
+            foreach ($errors as $error) {
+                $error_count += count($error);
             }
         } else {
-            if ($local_import) {
-                Utils::logger("{$file_path} does not exist.");
-            } else {
-                Utils::logger("{$locamotion_url} does not exist, http code was {$http_response}");
-            }
-
-            return $result;
-        }
-
-        if ($result['imported']) {
-            Utils::logger('Locamotion data extracted and added to local repository.');
-        } else {
-            Utils::logger('No new strings from Locamotion added to local repository.');
-        }
-
-        return $result;
-    }
-
-    /*
-     * Read local .po file, return updated strings
-     *
-     * @param   string   $po_filename     Path to po file
-     * @param   array    $locale_data     Array of data for locale file
-     * @param   boolean  $output_message  True (default) to output messages in console
-     * @return  array                     Result of import (boolean), errors (array), updated strings (array)
-     */
-    public static function importLocalPoFile($po_filename, $locale_data, $output_message = true)
-    {
-        $result = [
-          'imported' => false,
-          'errors'   => [],
-          'strings'  => []
-        ];
-
-        // Read po file
-        $po_strings = self::loadPoFile($po_filename);
-
-        if (count($po_strings) == 0 && $output_message) {
-            Utils::logger('.po file is empty.');
-        } else {
-            foreach ($po_strings as $string_id => $translation) {
-                if (isset($locale_data['strings'][$string_id])) {
-                    // String is available in the local lang file, check if is different
-                    if (Utils::startsWith($po_strings[$string_id], ';')) {
-                        // Translations can't start with ";"
-                        $result['errors'][] = "Translation starts with ;\n{$po_strings[$string_id]}";
-                    } elseif ($po_strings[$string_id] !== $locale_data['strings'][$string_id]) {
-                        // Translation in the .po file is different
-                        if ($output_message) {
-                            Utils::logger("Updated translation: {$string_id} => {$translation}");
-                        }
-                        $locale_data['strings'][$string_id] = $translation;
-                        $result['imported'] = true;
-                    }
-                }
-            }
-            $result['strings'] = $locale_data['strings'];
-        }
-
-        if ($output_message) {
-            if ($result['imported']) {
-                Utils::logger('Data imported.');
-            } else {
-                Utils::logger('No data imported.');
+            // Specific type of error, which means a sub-array of 'errors'
+            if (isset($errors[$error_type])) {
+                $error_count = count($errors[$error_type]);
             }
         }
 
-        return $result;
+        return $error_count;
     }
 }

--- a/classes/Langchecker/Project.php
+++ b/classes/Langchecker/Project.php
@@ -1,20 +1,22 @@
 <?php
 namespace Langchecker;
 
-/*
+/**
  * Project class
  *
  * Get data from the project: list of supported locales, file paths, etc.
+ *
  *
  * @package Langchecker
  */
 class Project
 {
-    /*
+    /**
      * Return reference locale for website
      *
-     * @param   array  $website Website data
-     * @return  string          Reference locale
+     * @param   array   $website  Website data
+     *
+     * @return  string            Reference locale
      */
     public static function getReferenceLocale($website)
     {
@@ -25,12 +27,14 @@ class Project
         return 'en-US';
     }
 
-    /*
+    /**
      * Return supported locales for website
      *
      * @param   array   $website            Website data
      * @param   string  $filename           File name, default empty
-     * @param   array   $langfiles_subsets  Array of supported locales for specific file, default empty
+     * @param   array   $langfiles_subsets  Array of supported locales for
+     *                                      specific file, default empty
+     *
      * @return  array                       Supported locales
      */
     public static function getSupportedLocales($website, $filename = '', $langfiles_subsets = [])
@@ -50,13 +54,15 @@ class Project
         return $website[3];
     }
 
-    /*
+    /**
      * Check if locale is supported for website
      *
      * @param   array    $website            Website data
      * @param   string   $locale             Requested locale
      * @param   string   $filename           File name, default empty
-     * @param   array    $langfiles_subsets  Array of supported locales for specific file, default empty
+     * @param   array    $langfiles_subsets  Array of supported locales for
+     *                                       specific file, default empty
+     *
      * @return  boolean                      True if locale is supported
      */
     public static function isSupportedLocale($website, $locale, $filename = '', $langfiles_subsets = [])
@@ -65,12 +71,13 @@ class Project
                         self::getSupportedLocales($website, $filename, $langfiles_subsets));
     }
 
-    /*
+    /**
      * Check if file is marked as critical
      *
      * @param   array    $website   Website data
      * @param   string   $filename  File name
      * @param   string   $locale    Locale
+     *
      * @return  boolean             True if file is marked as critical
      */
     public static function isCriticalFile($website, $filename, $locale)
@@ -88,12 +95,13 @@ class Project
         return false;
     }
 
-    /*
+    /**
      * Return a list of flags associated to the file
      *
      * @param   array    $website   Website data
      * @param   string   $filename  File name
      * @param   string   $locale    Locale
+     *
      * @return  array               Array of flags for this file+locale
      */
     public static function getFileFlags($website, $filename, $locale)
@@ -116,10 +124,11 @@ class Project
         return $file_flags;
     }
 
-    /*
+    /**
      * Return website's name
      *
      * @param   array   $website  Website data
+     *
      * @return  string            Website name
      */
     public static function getWebsiteName($website)
@@ -127,10 +136,11 @@ class Project
         return $website[0];
     }
 
-    /*
+    /**
      * Return list of files managed for website
      *
      * @param   array  $website  Website data
+     *
      * @return  array            Array of managed files, sorted alphabetically
      */
     public static function getWebsiteFiles($website)
@@ -141,12 +151,13 @@ class Project
         return $file_list;
     }
 
-    /*
+    /**
      * Return full local path to filename
      *
      * @param   array   $website   Website data
      * @param   string  $locale    Requested locale
      * @param   string  $filename  File name
+     *
      * @return  string             Path to file
      */
     public static function getLocalFilePath($website, $locale, $filename)
@@ -154,12 +165,13 @@ class Project
         return $website[1] . $website[2] . $locale . '/' . $filename;
     }
 
-    /*
+    /**
      * Return full public path to filename
      *
      * @param   array   $website   Website data
      * @param   string  $locale    Requested locale
      * @param   string  $filename  File name
+     *
      * @return  string             Path to file
      */
     public static function getPublicFilePath($website, $locale, $filename)
@@ -167,11 +179,12 @@ class Project
         return $website[6] . $website[2] . $locale . '/' . $filename;
     }
 
-    /*
+    /**
      * Return website path repo
      *
      * @param   array   $website  Website data
      * @param   string  $locale   Requested locale
+     *
      * @return  string            Path to file
      */
     public static function getPublicRepoPath($website, $locale)
@@ -179,11 +192,12 @@ class Project
         return $website[6] . $website[2] . $locale . '/';
     }
 
-    /*
+    /**
      * Return websites that use a specific data type as source
      *
      * @param   array   $sites    Array of all supported websites
      * @param   array   $type     Type of data (lang, raw)
+     *
      * @return  array             Array of website records
      */
     public static function getWebsitesByDataType($sites, $type)
@@ -197,10 +211,11 @@ class Project
         return $sites;
     }
 
-    /*
+    /**
      * Return data type used by website
      *
      * @param   array   $website  Website data
+     *
      * @return  string            Type of data (lang, raw)
      */
     public static function getWebsiteDataType($website)
@@ -208,10 +223,11 @@ class Project
         return $website[8];
     }
 
-    /*
+    /**
      * Return user base coverage for list of locales
      *
      * @param   array   $locales  Array of locales
+     *
      * @return  string            Percent value of our coverage for the user base
      */
     public static function getUserBaseCoverage($locales, $adu)
@@ -234,11 +250,13 @@ class Project
         return number_format(array_sum($locales) / (array_sum($adu) - $english_adu) *100, 2);
     }
 
-    /*
+    /**
      * Return name of the view based on the request parameters
      *
      * @param   array   $request  Array of params extracted from URL
-     * @return  array             Array with name of the file to use, if we need a template or not and its name
+     *
+     * @return  array             Array with name of the file to use, if we need
+     *                            a template or not and its name
      */
     public static function selectView($request)
     {

--- a/classes/Langchecker/RawManager.php
+++ b/classes/Langchecker/RawManager.php
@@ -1,7 +1,7 @@
 <?php
 namespace Langchecker;
 
-/*
+/**
  * RawManager class
  *
  * This class is used to compare reference and localized "raw" files.
@@ -9,16 +9,18 @@ namespace Langchecker;
  * (e.g. text files), so we can only determine their status based on
  * content comparison (through sha1 hashes) and dates.
  *
+ *
  * @package Langchecker
  */
 class RawManager
 {
-    /*
+    /**
      * Compare reference and localized raw file
      *
      * @param   array   $website   Website data
      * @param   string  $locale    Locale to analyze
      * @param   string  $filename  File to analyze
+     *
      * @return  array              Results from comparison
      */
     public static function compareRawFiles($website, $locale, $filename)

--- a/classes/Langchecker/Utils.php
+++ b/classes/Langchecker/Utils.php
@@ -1,31 +1,34 @@
 <?php
 namespace Langchecker;
 
-/*
+/**
  * Utils class
  *
  * Utility functions like string management.
+ *
  *
  * @package Langchecker
  */
 class Utils
 {
-    /*
+    /**
      * Remove a substring from the left of a string, return the trimmed result
      *
      * @param   string  $origin     Original string
      * @param   string  $substring  Substring to remove
+     *
      * @return  string              Resulting string
      */
     public static function leftStrip($origin, $substring)
     {
-        return trim(substr($origin, strlen($substring)));
+        return trim(substr($origin, mb_strlen($substring)));
     }
 
-    /*
+    /**
      * Return a string without extra tags like {ok}
      *
      * @param   string  $origin  Original string
+     *
      * @return  string           String cleaned from extra-tags
      */
     public static function cleanString($origin)
@@ -33,24 +36,46 @@ class Utils
         return trim(str_ireplace('{ok}', '', $origin));
     }
 
-    /*
-     * Check if $haystack starts with the $needle string
+    /**
+     * Check if $haystack starts with a string in $needles.
+     * $needles can be a string or an array of strings.
      *
-     * @param   string   $haystack  Full string
-     * @param   string   $needle    Substring to search
-     * @return  boolean             True is string starts with $needle
+     * @param   string   $haystack  String to analyse
+     * @param   array    $needles   The string to look for
+     *
+     * @return  boolean  True       if the $haystack string starts with a
+     *                              string in $needles
      */
-    public static function startsWith($haystack, $needle)
+    public static function startsWith($haystack, $needles)
     {
-        return ! strncmp($haystack, $needle, strlen($needle));
+        foreach((array) $needles as $prefix) {
+            if (! strncmp($haystack, $prefix, mb_strlen($prefix))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    /*
+    /**
+     * Get multibyte UTF-8 string length, html tags stripped
+     *
+     * @param   string  $str  A multibyte string
+     *
+     * @return  int           The length of the string after removing all html
+     */
+    public static function getLength($str)
+    {
+        return mb_strlen(strip_tags($str), 'UTF-8');
+    }
+
+    /**
      * Function sanitizing a string or an array of strings.
      *
-     * @param   array         $origin    String to sanitize
+     * @param   mixed         $origin    String/Array of strings to sanitize
      * @param   boolean       $isarray   If $origin must be treated as array
-     * @return  string/array             Sanitized string or array
+     *
+     * @return  mixed                    Sanitized string or array
      */
     public static function secureText($origin, $isarray = true)
     {
@@ -83,10 +108,11 @@ class Utils
         return ($isarray == true) ? $sanitized : $sanitized[0];
     }
 
-    /*
+    /**
      * Highlight Python variables in string
      *
      * @param   array   $origin  Original string
+     *
      * @return  string           String withon Python variables marked with <em>
      */
     public static function highlightPythonVar($origin)
@@ -101,10 +127,11 @@ class Utils
         return $origin;
     }
 
-    /*
+    /**
      * Return false if file is not in UTF-8 or US-Ascii format
      *
      * @param   string   $filename  File to analyze
+     *
      * @return  boolean             False if file is in the wrong encoding
      */
     public static function isUTF8($filename)
@@ -116,11 +143,13 @@ class Utils
         return ($type == 'utf-8' || $type == 'us-ascii') ? true : false;
     }
 
-    /*
+    /**
      * Return
      *
-     * @param   string $filename  File to analyze
-     * @return  int               Timestamp of last commit from SVN, or local if that fails
+     * @param   string  $filename  File to analyze
+     *
+     * @return  int                Timestamp of last commit from SVN,
+     *                             or local if that fails
      */
     public function getSVNCommitTimestamp($filename)
     {
@@ -136,7 +165,7 @@ class Utils
         return $date->getTimestamp();
     }
 
-    /*
+    /**
      * Print error, quit application if requested
      *
      * @param  string  $message  Message to display
@@ -150,10 +179,11 @@ class Utils
         }
     }
 
-    /*
+    /**
      * Check type of EOL used in the file
      *
      * @param   string  $line  First line of the file
+     *
      * @return  string         End of line characters, default Unix "\n"
      */
     public static function checkEOL($line)
@@ -165,7 +195,7 @@ class Utils
         return "\n";
     }
 
-    /*
+    /**
      * Save file in path, create folders if necessary
      *
      * @param  string  $path     File path
@@ -186,11 +216,12 @@ class Utils
         file_put_contents("{$dir}/{$file}", $content);
     }
 
-    /*
+    /**
      * Read GET parameter if set, or fallback
      *
      * @param   string  $param     GET parameter to check
      * @param   string  $fallback  Optional fallback value
+     *
      * @return  string             Parameter value, or fallback
      */
     public static function getQueryParam($param, $fallback = '') {
@@ -203,12 +234,13 @@ class Utils
         return $fallback;
     }
 
-    /*
+    /**
      * Read CLI parameter if set, or fallback
      *
      * @param   integer  $paramnum  Argument number
      * @param   array    $options   Array of parameters
      * @param   string   $fallback  Optional fallback value
+     *
      * @return  string              Parameter value, or fallback
      */
     public static function getCliParam($paramnum, $options, $fallback = '') {

--- a/classes/Transvision/Json.php
+++ b/classes/Transvision/Json.php
@@ -3,11 +3,12 @@ namespace Transvision;
 
 class Json
 {
-    /*
+    /**
      * Return a json/jsonp representation of data and exit
      *
      * @param   array   $data   Data in json format
      * @param   string  $jsonp  Function name, default to false
+     *
      * @return  string          Json feed
      */
     public static function output(array $data, $jsonp = false, $pretty_print = false)
@@ -30,10 +31,11 @@ class Json
         return $json;
     }
 
-    /*
+    /**
      * Return a array from a local or remote file json file
      *
      * @param   string  $uri  Uri of the resource
+     *
      * @return  array         Data in array format
      */
     public static function fetch($uri)

--- a/classes/Webdashboard/Bugzilla.php
+++ b/classes/Webdashboard/Bugzilla.php
@@ -1,0 +1,197 @@
+<?php
+namespace Webdashboard;
+
+/**
+ * Bugzilla class
+ *
+ * Bugzilla functions: perform searches, map locale code to componente name
+ *
+ *
+ * @package Webdashboard
+ */
+class Bugzilla {
+    /**
+     * @var  array  $locales_mappings  Map locale codes to Bugzilla's component name
+     */
+    private static $locales_mappings = [
+                'ach'       => 'Acholi',
+                'af'        => 'Afrikaans',
+                'an'        => 'Aragonese',
+                'ar'        => 'Arabic',
+                'as'        => 'Assamese',
+                'ast'       => 'Asturian',
+                'az'        => 'Azerbaijani',
+                'be'        => 'Belarusian',
+                'bg'        => 'Bulgarian',
+                'bn-BD'     => 'Bengali',
+                'bn-BD-www' => 'Bengali (Bangladesh)',
+                'bn-IN'     => 'Bengali (India)',
+                'br'        => 'Breton',
+                'bs'        => 'Bosnian',
+                'ca'        => 'Catalan',
+                'cs'        => 'Czech',
+                'csb'       => 'Kashubian',
+                'cy'        => 'Welsh',
+                'da'        => 'Danish',
+                'de'        => 'German',
+                'dsb'       => 'Lower Sorbian',
+                'el'        => 'Greek',
+                'en-GB'     => 'English (United Kingdom)',
+                'en-GB-www' => 'English (British)',
+                'eo'        => 'Esperanto',
+                'es-AR'     => 'Spanish (Argentina)',
+                'es-CL'     => 'Spanish (Chile)',
+                'es-ES'     => 'Spanish',
+                'es-ES-www' => 'Spanish (Spain)',
+                'es-MX'     => 'Spanish (Mexico)',
+                'et'        => 'Estonian',
+                'eu'        => 'Basque',
+                'fa'        => 'Persian',
+                'ff'        => 'Fulah',
+                'fi'        => 'Finnish',
+                'fr'        => 'French',
+                'fy-NL'     => 'Frisian',
+                'ga-IE'     => 'Irish',
+                'ga-IE-www' => 'Irish (Ireland)',
+                'gd'        => 'Scottish Gaelic',
+                'gd-www'    => 'Gaelic (Scotland)',
+                'gl'        => 'Galician',
+                'gu-IN'     => 'Gujarati',
+                'he'        => 'Hebrew',
+                'hi-IN'     => 'hindi',
+                'hi-IN-www' => 'Hindi (India)',
+                'hr'        => 'Croatian',
+                'hsb'       => 'Upper Sorbian',
+                'hu'        => 'Hungarian',
+                'hy-AM'     => 'Armenian',
+                'id'        => 'Indonesian',
+                'is'        => 'Icelandic',
+                'it'        => 'Italian',
+                'ja'        => 'Japanese',
+                'ka'        => 'Georgian',
+                'kk'        => 'Kazakh',
+                'km'        => 'Khmer',
+                'kn'        => 'Kannada',
+                'ko'        => 'Korean',
+                'ku'        => 'Kurdish',
+                'lg'        => 'Luganda',
+                'lij'       => 'Ligurian',
+                'lt'        => 'Lithuanian',
+                'lv'        => 'Latvian',
+                'mai'       => 'Maithili',
+                'mk'        => 'Macedonian',
+                'ml'        => 'Malayalam',
+                'mn'        => 'Mongolian',
+                'mr'        => 'Marathi',
+                'ms'        => 'Malay',
+                'my'        => 'Burmese',
+                'nb-NO'     => 'Norwegian Bokmål',
+                'nb-NO-www' => 'Norwegian (Bokmål)',
+                'nl'        => 'Dutch',
+                'nn-NO'     => 'Norwegian Nynorsk',
+                'nn-NO-www' => 'Norwegian (Nynorsk)',
+                'nso'       => 'Northern Sotho (Pedi)',
+                'nso-www'   => 'Northern Sotho',
+                'oc'        => 'Occitan',
+                'oc-www'    => 'Occitan (Lengadocian)',
+                'or'        => 'Oriya',
+                'pa-IN'     => 'Punjabi',
+                'pl'        => 'Polish',
+                'pt-BR'     => 'Portuguese (Brazil)',
+                'pt-BR-www' => 'Portuguese (Brazilian)',
+                'pt-PT'     => 'Portuguese',
+                'pt-PT-www' => 'Portuguese (Portugal)',
+                'rm'        => 'Romansh',
+                'ro'        => 'Romanian',
+                'ru'        => 'Russian',
+                'sat'       => 'Santali',
+                'si'        => 'Sinhala',
+                'sk'        => 'Slovak',
+                'sl'        => 'Slovene',
+                'sl-www'    => 'Slovenian',
+                'son'       => 'Songhay',
+                'sq'        => 'Albanian',
+                'sr'        => 'Serbian',
+                'sv-SE'     => 'Swedish',
+                'sw'        => 'Swahili',
+                'ta'        => 'Tamil',
+                'ta-LK'     => 'Tamil (Sri Lanka)',
+                'te'        => 'Telugu',
+                'th'        => 'Thai',
+                'tr'        => 'Turkish',
+                'uk'        => 'Ukrainian',
+                'ur'        => 'Urdu',
+                'uz'        => 'Uzbek',
+                'vi'        => 'Vietnamese',
+                'wo'        => 'Wolof',
+                'xh'        => 'Xhosa',
+                'zh-CN'     => 'Chinese (Simplified)',
+                'zh-TW'     => 'Chinese (Traditional)',
+                'zu'        => 'Zulu',
+            ];
+
+    /**
+     * Fetch a remote CSV file generated by an advanced search in Bugzilla
+     *
+     * @param   string  $csv   URI of the CSV file
+     * @param   string  $full  Return short or long results (default to false)
+     *
+     * @return  array          List of bugs and their descriptions
+     */
+    public static function getBugsFromCSV($csv, $full = false)
+    {
+        $fullBugs = [];
+        $shortBugs = [];
+        $singleBug = [];
+
+        $file_handle = fopen($csv, 'r');
+        if ($file_handle !== false) {
+            while (($data = fgetcsv($file_handle, 300, ',')) !== false) {
+                if ($data[0] == 'bug_id') {
+                    /* If it starts with bug_id, I'm reading the first line
+                     * with all field names
+                     */
+                    $fields = $data;
+                    continue;
+                }
+                foreach ($fields as $key => $field) {
+                    $singleBug[$field] = $data[$key];
+                }
+                $shortBugs[$singleBug['bug_id']] = $singleBug['short_desc'];
+                $fullBugs[] = $singleBug;
+            }
+            fclose($file_handle);
+        }
+
+        return $full ? $fullBugs : $shortBugs;
+    }
+
+    /**
+     * Given a locale code and a product, determine the correct component name
+     * on Bugzilla
+     *
+     * @param   string   $locale      Locale code
+     * @param   string   $component   If I need the locale code for Mozilla
+     *                                Localizations or www.mozilla.org (default)
+     * @param   boolean  $log_errors  If I need to log the error for missing locale
+     *
+     * @return  string                "Locale / Language name" for Bugzilla queries
+     */
+    public static function getBugzillaLocaleField($locale, $component = 'www', $log_errors = true) {
+        $locale_web = "{$locale}-www";
+        if ($component == 'www' && isset(self::$locales_mappings[$locale_web])) {
+            // This locale has a specific language name for www.mozilla.org
+            return $locale . ' / ' . self::$locales_mappings[$locale_web];
+        }
+        if (isset(self::$locales_mappings[$locale])) {
+            // Return the default language name if it exists
+            return $locale . ' / ' . self::$locales_mappings[$locale];
+        }
+        // Locale does not exist in mapping. Log error if necessary
+        if ($log_errors) {
+            error_log("Missing locale {$locale} in locale mappings (Bugzilla Class)");
+        }
+
+        return $locale;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
 
     "autoload": {
         "psr-0": {
-            "Transvision": "classes/",
-            "Langchecker": "classes/"
+            "Langchecker": "classes/",
+            "Webdashboard": "classes/",
+            "Transvision": "classes/"
         }
     }
 }

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -87,7 +87,7 @@ h1 span {
     box-shadow: 1px 1px 6px #4a412e;
     font-size: 15px;
     height: 50px;
-    line-height: 50px;
+    line-height: 3.3;
     margin: 0;
     padding: 0 20px;
     position: absolute;
@@ -183,6 +183,10 @@ tr.tabletotals th {
     margin: 2px;
 }
 
+.file_done:hover {
+    color: #56c7fc;
+}
+
 .file_activated {
     border-right: 8px solid #92cc6e;
 }
@@ -224,6 +228,7 @@ tr.tabletotals th {
 .file_container .sidetable {
     float: right;
     margin: 0 0 20px 20px;
+    font-size: 0.9em;
 }
 
 table.python {

--- a/scripts/import_locamotion
+++ b/scripts/import_locamotion
@@ -112,7 +112,7 @@ foreach ($file_list as $current_filename) {
         }
 
         // Import data from locamotion
-        $locamotion_import = LangManager::importLocamotion($locale_data, $current_filename, $current_locale, $locamotion_repo);
+        $locamotion_import = GetTextManager::importLocamotion($locale_data, $current_filename, $current_locale, $locamotion_repo);
 
         // Check for errors, even if there are no imported strings
         if ($locamotion_import['errors']) {

--- a/scripts/import_po
+++ b/scripts/import_po
@@ -32,7 +32,7 @@ Utils::logger("lang file (destination):\n{$cli_lang_filename}\n");
 $reference_data = DotLangParser::parseFile($cli_lang_filename, true);
 $locale_data = DotLangParser::parseFile($cli_lang_filename, false);
 
-$po_import = LangManager::importLocalPoFile($cli_po_filename, $locale_data);
+$po_import = GetTextManager::importLocalPoFile($cli_po_filename, $locale_data);
 
 if ($po_import['imported']) {
     // I have strings to save

--- a/scripts/mark_active
+++ b/scripts/mark_active
@@ -37,7 +37,7 @@ foreach ($supported_locales as $current_locale) {
 
     $todo = count($locale_analysis['Identical']) +
             count($locale_analysis['Missing']) +
-            count($locale_analysis['python_vars']);
+            LangManager::countErrors($locale_analysis['errors']);
     if ($todo == 0) {
         if (! $locale_analysis['activated']) {
             // File is ready, add ## active ## tag

--- a/tests/testfiles/dotlang/en-US/page.lang
+++ b/tests/testfiles/dotlang/en-US/page.lang
@@ -18,6 +18,11 @@ Hello
 Test
 
 
+## MAX_LENGTH: 12
+;Save file
+Save file
+
+
 ## TAG: test_tag
 ;01
 01

--- a/tests/testfiles/dotlang/it/page.lang
+++ b/tests/testfiles/dotlang/it/page.lang
@@ -16,6 +16,9 @@ Ciao
 ;Test
 
 
+;Save file
+Salva file troppo lungo
+
 
 ;01
 1

--- a/tests/testfiles/dotlang/it/updated_page.lang
+++ b/tests/testfiles/dotlang/it/updated_page.lang
@@ -19,6 +19,10 @@ Ciao
 Test
 
 
+;Save file
+Salva file troppo lungo
+
+
 ;01
 1
 

--- a/tests/testfiles/dotlang/toto.lang
+++ b/tests/testfiles/dotlang/toto.lang
@@ -45,3 +45,13 @@ Bonjour
 ;String with tag
 Chaîne avec étiquette
 
+
+## MAX_LENGTH: 12
+;Save file
+Save file
+
+
+## MAX_LENGTH: ABC
+;Save file wrong
+Save file wrong
+

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -33,6 +33,12 @@ class DotLangParser extends atoum\test
                     '## TAG: bound tag',
                     ';String with tag',
                     'Chaîne avec étiquette',
+                    '## MAX_LENGTH: 12',
+                    ';Save file',
+                    'Save file',
+                    '## MAX_LENGTH: ABC',
+                    ';Save file wrong',
+                    'Save file wrong'
                 ]
             ],
         ];
@@ -127,5 +133,17 @@ class DotLangParser extends atoum\test
         $this
             ->string($dotlang_data['tag_bindings']['String with tag'])
                 ->isEqualTo('bound tag');
+
+        // Check character limits
+        $this
+            ->integer(count($dotlang_data['max_lengths']))
+                ->isEqualTo(2);
+        $this
+            ->integer($dotlang_data['max_lengths']['Save file'])
+                ->isEqualTo(12);
+
+        $this
+            ->integer($dotlang_data['max_lengths']['Save file wrong'])
+                ->isEqualTo(0);
     }
 }

--- a/tests/units/Langchecker/GetTextManager.php
+++ b/tests/units/Langchecker/GetTextManager.php
@@ -1,0 +1,84 @@
+<?php
+namespace tests\units\Langchecker;
+
+use atoum;
+use Langchecker\GetTextManager as _GetTextManager;
+use Langchecker\DotLangParser as _DotLangParser;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class GetTextManager extends atoum\test
+{
+    public function testLoadPoFile()
+    {
+        $filepath = TEST_FILES . 'gettext/test.po';
+        $obj = new _GetTextManager();
+
+        $strings = $obj->loadPoFile($filepath);
+
+        // Total number of strings
+        $this
+            ->integer(count($strings))
+                ->isEqualTo(9);
+
+        // Identical string
+        $this
+            ->string($strings['Download'])
+                ->isEqualTo('Download {ok}');
+
+        // Single line string
+        $this
+            ->string($strings['Different by Design'])
+                ->isEqualTo('De todos. Para todos');
+
+        // Multiline string
+        $this
+            ->string($strings['As a non-profit, we’re free to innovate on your behalf without any pressure to compromise.'])
+                ->isEqualTo('Como una organización sin fines de lucro, somos libres de innovar en tu nombre sin presión o compromiso alguno.');
+    }
+
+    public function testImportLocalPoFile()
+    {
+        $po_filepath = TEST_FILES . 'gettext/test.po';
+        $lang_filepath = TEST_FILES . 'gettext/test.lang';
+        $obj = new _GetTextManager();
+
+        $locale_data = _DotLangParser::parseFile($lang_filepath, false);
+        $po_import = $obj->importLocalPoFile($po_filepath, $locale_data, false);
+
+        // I should have imported data
+        $this
+            ->boolean($po_import['imported'])
+                ->isTrue();
+
+        // I should have one error
+        $this
+            ->integer(count($po_import['errors']))
+                ->isEqualTo(1);
+
+        // Test one translated string
+        $this
+            ->string($po_import['strings']['Innovating <span>for you</span>'])
+                ->isEqualTo('¡Inovando <span>para ti!</span>');
+
+        // Test one translated string in both lang and po file (second has precedence)
+        $this
+            ->string($po_import['strings']['Fast, flexible, <span>secure</span>'])
+                ->isEqualTo('Rápido, flexible, seguro');
+
+        // Empty translation in .po file, existing in .lang file
+        $this
+            ->string($po_import['strings']['Empty'])
+                ->isEqualTo('test');
+
+        // Test one identical string
+        $this
+            ->string($po_import['strings']['Download'])
+                ->isEqualTo('Download {ok}');
+
+        // Test one translation starting with ; (should be ignored)
+        $this
+            ->string($po_import['strings']['Download test'])
+                ->isEqualTo('Download test');
+    }
+}

--- a/tests/units/Langchecker/Utils.php
+++ b/tests/units/Langchecker/Utils.php
@@ -54,21 +54,43 @@ class Utils extends atoum\test
     public function startsWithDP()
     {
         return [
-            ['test string', 't'],
-            [';test string', ';'],
-            ['## TAG: test string', '## TAG:'],
+            ['test string', 't', true],
+            [';test string', ';', true],
+            ['## TAG: test string', '## TAG:', true],
+            ['test string', ['t'], true],
+            ['## TAG: test string', ['## TAG:', '## NOTE:'], true],
+            ['## active ##', ['## TAG:', '## NOTE:'], false],
         ];
     }
 
     /**
      * @dataProvider startsWithDP
      */
-    public function testStartsWith($a, $b)
+    public function testStartsWith($a, $b, $c)
     {
         $obj = new _Utils();
         $this
             ->boolean($obj->startsWith($a, $b))
-                ->isTrue();
+                ->isEqualTo($c);
+    }
+
+    public function getLengthDP()
+    {
+        return [
+            ['Le cheval  blanc ', 17],
+            ['મારુ ઘર પાનું બતાવો', 19],
+        ];
+    }
+
+    /**
+     * @dataProvider getLengthDP
+     */
+    public function testGetLength($a, $b)
+    {
+        $obj = new _Utils();
+        $this
+            ->integer($obj->getLength($a))
+                ->isEqualTo($b);
     }
 
     public function secureTextDP()

--- a/tests/units/Webdashboard/Bugzilla.php
+++ b/tests/units/Webdashboard/Bugzilla.php
@@ -1,0 +1,197 @@
+<?php
+namespace Bugzilla;
+
+/**
+ * Bugzilla class
+ *
+ * Bugzilla functions: perform searches, map locale code to componente name
+ *
+ *
+ * @package Bugzilla
+ */
+class Bugzilla {
+    /**
+     * @var  array  $locales_mappings  Map locale codes to Bugzilla's component name
+     */
+    private static $locales_mappings = [
+                'ach'       => 'Acholi',
+                'af'        => 'Afrikaans',
+                'an'        => 'Aragonese',
+                'ar'        => 'Arabic',
+                'as'        => 'Assamese',
+                'ast'       => 'Asturian',
+                'az'        => 'Azerbaijani',
+                'be'        => 'Belarusian',
+                'bg'        => 'Bulgarian',
+                'bn-BD'     => 'Bengali',
+                'bn-BD-www' => 'Bengali (Bangladesh)',
+                'bn-IN'     => 'Bengali (India)',
+                'br'        => 'Breton',
+                'bs'        => 'Bosnian',
+                'ca'        => 'Catalan',
+                'cs'        => 'Czech',
+                'csb'       => 'Kashubian',
+                'cy'        => 'Welsh',
+                'da'        => 'Danish',
+                'de'        => 'German',
+                'dsb'       => 'Lower Sorbian',
+                'el'        => 'Greek',
+                'en-GB'     => 'English (United Kingdom)',
+                'en-GB-www' => 'English (British)',
+                'eo'        => 'Esperanto',
+                'es-AR'     => 'Spanish (Argentina)',
+                'es-CL'     => 'Spanish (Chile)',
+                'es-ES'     => 'Spanish',
+                'es-ES-www' => 'Spanish (Spain)',
+                'es-MX'     => 'Spanish (Mexico)',
+                'et'        => 'Estonian',
+                'eu'        => 'Basque',
+                'fa'        => 'Persian',
+                'ff'        => 'Fulah',
+                'fi'        => 'Finnish',
+                'fr'        => 'French',
+                'fy-NL'     => 'Frisian',
+                'ga-IE'     => 'Irish',
+                'ga-IE-www' => 'Irish (Ireland)',
+                'gd'        => 'Scottish Gaelic',
+                'gd-www'    => 'Gaelic (Scotland)',
+                'gl'        => 'Galician',
+                'gu-IN'     => 'Gujarati',
+                'he'        => 'Hebrew',
+                'hi-IN'     => 'hindi',
+                'hi-IN-www' => 'Hindi (India)',
+                'hr'        => 'Croatian',
+                'hsb'       => 'Upper Sorbian',
+                'hu'        => 'Hungarian',
+                'hy-AM'     => 'Armenian',
+                'id'        => 'Indonesian',
+                'is'        => 'Icelandic',
+                'it'        => 'Italian',
+                'ja'        => 'Japanese',
+                'ka'        => 'Georgian',
+                'kk'        => 'Kazakh',
+                'km'        => 'Khmer',
+                'kn'        => 'Kannada',
+                'ko'        => 'Korean',
+                'ku'        => 'Kurdish',
+                'lg'        => 'Luganda',
+                'lij'       => 'Ligurian',
+                'lt'        => 'Lithuanian',
+                'lv'        => 'Latvian',
+                'mai'       => 'Maithili',
+                'mk'        => 'Macedonian',
+                'ml'        => 'Malayalam',
+                'mn'        => 'Mongolian',
+                'mr'        => 'Marathi',
+                'ms'        => 'Malay',
+                'my'        => 'Burmese',
+                'nb-NO'     => 'Norwegian Bokmål',
+                'nb-NO-www' => 'Norwegian (Bokmål)',
+                'nl'        => 'Dutch',
+                'nn-NO'     => 'Norwegian Nynorsk',
+                'nn-NO-www' => 'Norwegian (Nynorsk)',
+                'nso'       => 'Northern Sotho (Pedi)',
+                'nso-www'   => 'Northern Sotho',
+                'oc'        => 'Occitan',
+                'oc-www'    => 'Occitan (Lengadocian)',
+                'or'        => 'Oriya',
+                'pa-IN'     => 'Punjabi',
+                'pl'        => 'Polish',
+                'pt-BR'     => 'Portuguese (Brazil)',
+                'pt-BR-www' => 'Portuguese (Brazilian)',
+                'pt-PT'     => 'Portuguese',
+                'pt-PT-www' => 'Portuguese (Portugal)',
+                'rm'        => 'Romansh',
+                'ro'        => 'Romanian',
+                'ru'        => 'Russian',
+                'sat'       => 'Santali',
+                'si'        => 'Sinhala',
+                'sk'        => 'Slovak',
+                'sl'        => 'Slovene',
+                'sl-www'    => 'Slovenian',
+                'son'       => 'Songhay',
+                'sq'        => 'Albanian',
+                'sr'        => 'Serbian',
+                'sv-SE'     => 'Swedish',
+                'sw'        => 'Swahili',
+                'ta'        => 'Tamil',
+                'ta-LK'     => 'Tamil (Sri Lanka)',
+                'te'        => 'Telugu',
+                'th'        => 'Thai',
+                'tr'        => 'Turkish',
+                'uk'        => 'Ukrainian',
+                'ur'        => 'Urdu',
+                'uz'        => 'Uzbek',
+                'vi'        => 'Vietnamese',
+                'wo'        => 'Wolof',
+                'xh'        => 'Xhosa',
+                'zh-CN'     => 'Chinese (Simplified)',
+                'zh-TW'     => 'Chinese (Traditional)',
+                'zu'        => 'Zulu',
+            ];
+
+    /**
+     * Fetch a remote CSV file generated by an advanced search in Bugzilla
+     *
+     * @param   string  $csv   URI of the CSV file
+     * @param   string  $full  Return short or long results (default to false)
+     *
+     * @return  array          List of bugs and their descriptions
+     */
+    public static function getBugsFromCSV($csv, $full = false)
+    {
+        $fullBugs = [];
+        $shortBugs = [];
+        $singleBug = [];
+
+        $file_handle = fopen($csv, 'r');
+        if ($file_handle !== false) {
+            while (($data = fgetcsv($file_handle, 300, ',')) !== false) {
+                if ($data[0] == 'bug_id') {
+                    /* If it starts with bug_id, I'm reading the first line
+                     * with all field names
+                     */
+                    $fields = $data;
+                    continue;
+                }
+                foreach ($fields as $key => $field) {
+                    $singleBug[$field] = $data[$key];
+                }
+                $shortBugs[$singleBug['bug_id']] = $singleBug['short_desc'];
+                $fullBugs[] = $singleBug;
+            }
+            fclose($file_handle);
+        }
+
+        return $full ? $fullBugs : $shortBugs;
+    }
+
+    /**
+     * Given a locale code and a product, determine the correct component name
+     * on Bugzilla
+     *
+     * @param   string   $locale      Locale code
+     * @param   string   $component   If I need the locale code for Mozilla
+     *                                Localizations or www.mozilla.org (default)
+     * @param   boolean  $log_errors  If I need to log the error for missing locale
+     *
+     * @return  string                "Locale / Language name" for Bugzilla queries
+     */
+    public static function getBugzillaLocaleField($locale, $component = 'www', $log_errors = true) {
+        $locale_web = "{$locale}-www";
+        if ($component == 'www' && isset(self::$locales_mappings[$locale_web])) {
+            // This locale has a specific language name for www.mozilla.org
+            return $locale . ' / ' . self::$locales_mappings[$locale_web];
+        }
+        if (isset(self::$locales_mappings[$locale])) {
+            // Return the default language name if it exists
+            return $locale . ' / ' . self::$locales_mappings[$locale];
+        }
+        // Locale does not exist in mapping. Log error if necessary
+        if ($log_errors) {
+            error_log("Missing locale {$locale} in locale mappings (Bugzilla Class)");
+        }
+
+        return $locale;
+    }
+}

--- a/views/activation.inc.php
+++ b/views/activation.inc.php
@@ -49,7 +49,7 @@ foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
 
             $todo = count($locale_analysis['Identical']) +
                     count($locale_analysis['Missing']) +
-                    count($locale_analysis['python_vars']);
+                    LangManager::countErrors($locale_analysis['errors']);
             $activation_status = $locale_analysis['activated'] ? 'yes' : 'no';
 
             if (($todo == 0) && ($activation_status == 'no')) {

--- a/views/export.inc.php
+++ b/views/export.inc.php
@@ -37,6 +37,7 @@ foreach ($sites as $website) {
                 $export_data[$website_name][$displayed_filename]['missing'] = count($locale_analysis['Missing']);
                 $export_data[$website_name][$displayed_filename]['obsolete'] = count($locale_analysis['Obsolete']);
                 $export_data[$website_name][$displayed_filename]['translated'] = count($locale_analysis['Translated']);
+                $export_data[$website_name][$displayed_filename]['errors'] = LangManager::countErrors($locale_analysis['errors']);
             } else {
                 $file_analysis = RawManager::compareRawFiles($website, $current_locale, $filename);
                 $cmp_result = $file_analysis['cmp_result'];


### PR DESCRIPTION
**LangManager**
- Extract MAX_LENGTH from lang files
- Move ['python_vars'] to ['errors']['python'] to support more types of errors
- Add function countErrors
- Move functions for .po files into a new class
- Move error checks in separate functions (python, length)

**Utils**
- starsWith: accept array of strings as needle
- Use mb_strlen instead of strlen, add getLength

**GetTextManager**
- Functions to manage .po files originally in LangManager

**Views**
Expose number of errors in JSON, display errors in listsitesperlocale and errors view

Clean up phpDOC syntax in all classes.
