### PR TITLE
Remove critical status for Thunderbird page

### DIFF
--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -153,7 +153,6 @@ $lang_flags['www.mozilla.org'] = [
     'newsletter.lang'                         => [
         'critical' => ['de', 'es-ES', 'fr', 'hu', 'id', 'pl', 'pt-BR', 'ru'],
     ],
-    'thunderbird/start/release.lang'          => [ 'critical' => ['all'] ],
     'upgradedialog.lang'                      => [ 'critical' => ['all'] ],
 ];
 


### PR DESCRIPTION
I don't think that Thunderbird pages should have critical status, but I'm not the one to make the call ;-)
Leaving the PR here for now.