### PR TITLE
Improve scripts to import translations from Transvision

### DIFF
--- a/scripts/import_transvision_id
+++ b/scripts/import_transvision_id
@@ -80,15 +80,18 @@ foreach ($locale_list as $current_locale) {
     if ($locale_data['strings'][$source_string] != $source_string) {
         Utils::logger("Requested string is already translated for {$current_locale}.");
     } else {
-        $translated_string = $translations[$current_locale];
-        // Mark as {ok} if identical, if it's not mozilla_org
-        if ($translated_string == $source_string &&
-            $cli_repo != 'mozilla_org') {
-            $translated_string .= ' {ok}';
+        if (! isset($translations[$current_locale])) {
+            Utils::logger("Requested string is not available on Transvision for {$current_locale}.");
+        } else {
+            $translated_string = $translations[$current_locale];
+            // Mark as {ok} if identical
+            if ($translated_string == $source_string) {
+                $translated_string .= ' {ok}';
+            }
+            $locale_data['strings'][$source_string] = $translated_string;
+            Utils::logger("Updating string for {$current_locale}.");
+            $content = LangManager::buildLangFile($reference_data, $locale_data, $current_locale, $eol);
+            Utils::fileForceContent($locale_filename, $content);
         }
-        $locale_data['strings'][$source_string] = $translated_string;
-        Utils::logger("Updating string for {$current_locale}.");
-        $content = LangManager::buildLangFile($reference_data, $locale_data, $current_locale, $eol);
-        Utils::fileForceContent($locale_filename, $content);
     }
 }

--- a/scripts/import_transvision_string
+++ b/scripts/import_transvision_string
@@ -81,9 +81,8 @@ foreach ($locale_list as $current_locale) {
         if (count($translations) > 0) {
             // I use the first string available
             $translated_string = reset($translations)[$cli_string];
-            // Mark as {ok} if identical, if it's not mozilla_org
-            if ($translated_string == $cli_string &&
-                $cli_repo != 'mozilla_org') {
+            // Mark as {ok} if identical
+            if ($translated_string == $cli_string) {
                 $translated_string .= ' {ok}';
             }
             $locale_data['strings'][$cli_string] = $translated_string;


### PR DESCRIPTION
Starting from v3.6 mozilla.org results are as other repositories: if translation is missing the string is empty, not identical to English anymore.

Also improved import from id to avoid warnings (we filter out empty strings, but still try to check these locales).