### PR TITLE
lang_update: don't overwrite existing string when importing from other files

### DIFF
--- a/scripts/lang_update
+++ b/scripts/lang_update
@@ -92,9 +92,12 @@ foreach ($file_list as $current_filename) {
             $eol = PHP_EOL;
         }
 
-        // Incorporate strings from other lang files
+        /* Incorporate strings from other lang files.
+         * Keep $locale_date['strings'] as last parameter of array_merge to
+         * avoid overwriting existing strings.
+         */
         // $temp_data = LangManager::loadSource($lang_based_sites[0], $current_locale, 'main.lang');
-        // $locale_data['strings'] = array_merge($locale_data['strings'], $temp_data['strings']);
+        // $locale_data['strings'] = array_merge($temp_data['strings'], $locale_data['strings']);
 
         // Exceptions are managed in LangManager::manageStringExceptions
 


### PR DESCRIPTION
As explained on php.net for [array_merge](http://php.net/manual/en/function.array-merge.php).
> If the input arrays have the same string keys,
> then the later value for that key will overwrite
> the previous one.

The current strings should always be the last element of array_merge.