### PR TITLE
Support concept of 'obsolete' lang files

### DIFF
--- a/config/sources.inc.php
+++ b/config/sources.inc.php
@@ -119,6 +119,7 @@ $mozillaorg_lang = [
 $lang_flags['www.mozilla.org'] = [
     'download.lang'                           => [ 'critical' => ['all'] ],
     'download_button.lang'                    => [ 'critical' => ['all'] ],
+    'euballot.lang'                           => [ 'obsolete' => ['all'] ],
     'firefox/android/index.lang'              => [
         'critical' => ['all'],
         'opt-in'   => ['all'],
@@ -142,13 +143,17 @@ $lang_flags['www.mozilla.org'] = [
     'firefox/installer-help.lang'             => [ 'critical' => ['all'] ],
     'firefox/geolocation.lang'                => [ 'opt-in'   => ['all'] ],
     'firefox/os/devices.lang'                 => [ 'critical' => ['all'] ],
+    'firefox/os/index.lang'                   => [ 'obsolete' => ['all'] ],
     'firefox/os/index-new.lang'               => [ 'critical' => ['all'] ],
     'firefox/privacy_tour/privacy_tour.lang'  => [ 'critical' => ['all'] ],
     'firefox/sync.lang'                       => [ 'critical' => ['all'] ],
     'firefox/tiles.lang'                      => [ 'critical' => ['all'] ],
     'firefox/whatsnew.lang'                   => [ 'critical' => ['all'] ],
+    'firefoxflicks.lang'                      => [ 'obsolete' => ['all'] ],
+    'firefoxlive.lang'                        => [ 'obsolete' => ['all'] ],
     'firefoxos/firefoxos.lang'                => [ 'critical' => ['all'] ],
-    'firefoxtesting.lang'                     => [ 'critical' => ['all'] ],
+    'firefoxtesting.lang'                     => [ 'obsolete' => ['all'] ],
+    'foundationsection.lang'                  => [ 'obsolete' => ['all'] ],
     'foundation/annualreport/2012/index.lang' => [ 'critical' => ['all'] ],
     'legal/index.lang'                        => [ 'critical' => ['all'] ],
     'lightbeam/lightbeam.lang'                => [ 'opt-in'   => ['all'] ],
@@ -158,6 +163,7 @@ $lang_flags['www.mozilla.org'] = [
     'mozorg/about/manifesto.lang'             => [ 'opt-in'   => ['all'] ],
     'mozorg/about/history.lang'               => [ 'opt-in'   => ['all'] ],
     'mozorg/about/history-details.lang'       => [ 'opt-in'   => ['all'] ],
+    'mozorg/contribute.lang'                  => [ 'obsolete' => ['all'] ],
     'mozorg/contribute/index.lang'            => [
         'critical' => ['all'],
         'opt-in'   => ['all'],
@@ -166,8 +172,10 @@ $lang_flags['www.mozilla.org'] = [
         'critical' => ['all'],
         'opt-in'   => ['all'],
     ],
+    'mozorg/home.lang'                        => [ 'obsolete' => ['all'] ],
     'mozorg/home/index.lang'                  => [ 'critical' => ['all'] ],
     'mozorg/plugincheck.lang'                 => [ 'critical' => ['all'] ],
+    'mozspaces.lang'                          => [ 'obsolete' => ['all'] ],
     'newsletter/ios.lang'                     => [
         'critical' => $newsletter_locales,
     ],
@@ -175,6 +183,7 @@ $lang_flags['www.mozilla.org'] = [
         'critical' => $newsletter_locales,
     ],
     'privacy/privacy-day.lang'                => [ 'opt-in'   => ['all'] ],
+    'snippets.lang'                           => [ 'obsolete' => ['all'] ],
     'thunderbird/start/release.lang'          => [ 'critical' => ['all'] ],
     'upgradedialog.lang'                      => [ 'critical' => ['all'] ],
 ];

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -329,6 +329,10 @@ div.tip blockquote {
     padding: 2px 6px;
 }
 
+.obsolete {
+    color: #999;
+}
+
 /* Opt-in pages */
 .optin_filename {
     text-align: left;

--- a/views/countstrings.inc.php
+++ b/views/countstrings.inc.php
@@ -20,19 +20,18 @@ foreach ($mozilla as $current_locale) {
             continue;
         }
         foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
-            // Skip the loop if we don't have this lang file for the locale
-            if (! Project::isSupportedLocale($current_website, $current_locale, $langfiles_subsets, $current_filename)) {
+            if (! Project::isSupportedLocale($current_website, $current_locale, $current_filename, $langfiles_subsets) ||
+                ! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename)) ||
+                in_array('obsolete', Project::getFileFlags($current_website, $current_filename, $current_locale))) {
+                /*
+                 * Ignore file for this locale if:
+                 * - It's not supported
+                 * - It doesn't exist
+                 * - It's marked as obsolete
+                 */
                 continue;
             }
-            // Skip the locale for this file if it's missing
-            if (! is_file(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
-                continue;
-            }
-            // Skip the locale if we do have a lang file but don't need it for the locale
-            if (isset($langfiles_subsets[$current_website[0]][$current_filename])
-                && ! in_array($current_locale, $langfiles_subsets[$current_website[0]][$current_filename])) {
-                continue;
-            }
+
             $reference_data = LangManager::loadSource($current_website, $reference_locale, $current_filename);
             $locale_analysis = LangManager::analyzeLangFile($current_website, $current_locale, $current_filename, $reference_data);
 

--- a/views/export.inc.php
+++ b/views/export.inc.php
@@ -22,12 +22,14 @@ foreach ($sites as $website) {
                                   $filename :
                                   basename($filename);
 
+            $file_flags = Project::getFileFlags($website, $filename, $current_locale);
+
             if ($website_data_source == 'lang') {
                 // Load reference strings
                 $reference_data = LangManager::loadSource($website, $reference_locale, $filename);
                 $locale_filename = Project::getLocalFilePath($website, $current_locale, $filename);
-                if (! is_file($locale_filename)) {
-                    // File is missing
+                if (! is_file($locale_filename) || in_array('obsolete', $file_flags)) {
+                    // File is missing or marked as obsolete
                     continue;
                 }
 
@@ -53,7 +55,6 @@ foreach ($sites as $website) {
             }
 
             // Flags
-            $file_flags = Project::getFileFlags($website, $filename, $current_locale);
             if ($file_flags) {
                 $export_data[$website_name][$displayed_filename]['flags'] = $file_flags;
             }

--- a/views/listpages.inc.php
+++ b/views/listpages.inc.php
@@ -49,9 +49,14 @@ foreach ($displayed_sites as $site_index => $current_website) {
             $total_words += $nb_words;
             $total_files++;
 
-            $html_output .= "<tr>\n" .
-                            "  <td>{$current_filename}</td>\n" .
-                            '  <td>' .  Project::getLocalizedURL($reference_data, '', 'html') . "</td>\n" .
+            $html_output .= "<tr>\n";
+            // Check if the file is obsolete for all locales
+            if (in_array('obsolete', Project::getFileFlags($current_website, $current_filename, 'all'))) {
+                $html_output .= "  <td class='obsolete' title='Obsolete file'>{$current_filename}</td>\n";
+            } else {
+                $html_output .= "  <td>{$current_filename}</td>\n";
+            }
+            $html_output .= '  <td>' .  Project::getLocalizedURL($reference_data, '', 'html') . "</td>\n" .
                             "  <td><a class='table_small_link' href='?locale=all&amp;website={$site_index}&amp;file={$current_filename}'>Status</a></td>\n" .
                             "  <td><a class='table_small_link' href='?website={$site_index}&amp;file={$current_filename}&amp;action=translate&amp;show'>Show</a></td>\n" .
                             "  <td>{$nb_strings}</td>\n" .

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -31,12 +31,15 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
     $todo_files = '';
 
     foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
-        if (! Project::isSupportedLocale($current_website, $current_locale, $current_filename, $langfiles_subsets)) {
-            // File is not managed for this website+locale, ignore it
-            continue;
-        }
-        if (! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
-            // If the .lang file does not exist, just skip the locale for this file
+        if (! Project::isSupportedLocale($current_website, $current_locale, $current_filename, $langfiles_subsets) ||
+            ! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename)) ||
+            in_array('obsolete', Project::getFileFlags($current_website, $current_filename, $current_locale))) {
+            /*
+             * Ignore file for this locale if:
+             * - It's not supported
+             * - It doesn't exist
+             * - It's marked as obsolete
+             */
             continue;
         }
 


### PR DESCRIPTION
Hide them from JSON (for the webdashboard) and from the main view used by localizers.
Don't use them for counting strings.
Display them differently in listpages.