### PR TITLE
Issue #312: improve performance of error page

### DIFF
--- a/config/settings.inc.php.ini
+++ b/config/settings.inc.php.ini
@@ -16,3 +16,5 @@ $repo12 = '/localpath/to/svn/l10n-misc/googleplay/';
 
 // Path to local clone of Locamotion's repo
 $locamotion_repo  = '/localpath/to/git/mozilla-lang/';
+
+const DEBUG = false;

--- a/templates/template.inc.php
+++ b/templates/template.inc.php
@@ -17,8 +17,16 @@
 	</div>
 </div>
 <?php
-    echo "<!-- Elapsed time (s): " . round((microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]), 4) . " -->\n";
-    echo "<!-- Memory usage (MB): " . round(memory_get_peak_usage(true) / (1024 * 1024), 2) . " -->\n";
+$time   = 'Elapsed time (s): ' . round((microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]), 4);
+$memory = 'Memory usage (MB): ' . round(memory_get_peak_usage(true) / (1024 * 1024), 2);
+
+print "<!-- " . $time . " -->\n";
+print "<!-- " . $memory . " -->\n";
+
+if (defined('DEBUG') && DEBUG) {
+    error_log($time);
+    error_log($memory);
+}
 ?>
 </body>
 </html>

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -151,4 +151,12 @@ class DotLangParser extends atoum\test
             ->integer($dotlang_data['max_lengths']['Save file wrong'])
                 ->isEqualTo(0);
     }
+
+    public function testgetMetaTags()
+    {
+        $obj = new _DotLangParser();
+        $this
+            ->array($obj->getMetaTags())
+                ->isEqualTo(['## NOTE:', '## TAG:', '## MAX_LENGTH:', '## URL:']);
+    }
 }


### PR DESCRIPTION
- faster Utils::isUTF8() by giving the path of the Magic mime file on the server
- store parsed English reference files in a static property instead of reparsing them every time
- in DotLangParser::ParseFile() avoid reparsing the whole file in the main loop for file metadata once we are already parsing strings
- Utils::starstWith() && Utils::leftStrip() have specific cases for searching ; and # with less calculation (on the error page we call these functions up to 2 million times)
- new DotLangParser::getMetaTags() utility function to return the list of tags we use in lang files
- moved parsing of reference metadata to a private DotLangParser::extractReferenceMetaData() property to make parseFile() more readable

Locally, the new version is 4 times faster for me, since this page is heavy on CPU use, results may be lower on our community server which is not particularily fast.