### PR TITLE
More performance improvement, mostly on the action=count view:

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -12,6 +12,13 @@ namespace Langchecker;
 class LangManager
 {
     /**
+     * We store in this variable if we need to check for errors when analysing lang files
+     *
+     * @var boolean
+     */
+    public static $error_checking = true;
+
+    /**
      * Load file, remove empty lines and return an array of strings
      *
      * @param array  $website  Website data
@@ -139,21 +146,24 @@ class LangManager
                     // Store in translated strings
                     $analysis_data['Translated'][] = $reference;
 
-                    // Search for Python errors
-                    $analysis_data['errors']['python'] = self::checkPythonErrors(
-                        $reference,
-                        $translation,
-                        $analysis_data['errors']['python']
-                    );
-
-                    if (isset($reference_data['max_lengths'][$reference])) {
-                        // Search for strings too long
-                        $analysis_data['errors']['length'] = self::checkLengthErrors(
+                    // Error Checking is not needed everytime we use analyseLangFile()
+                    if (self::$error_checking) {
+                        // Search for Python errors
+                        $analysis_data['errors']['python'] = self::checkPythonErrors(
                             $reference,
                             $translation,
-                            $reference_data['max_lengths'][$reference],
-                            $analysis_data['errors']['length']
+                            $analysis_data['errors']['python']
                         );
+
+                        if (isset($reference_data['max_lengths'][$reference])) {
+                            // Search for strings too long
+                            $analysis_data['errors']['length'] = self::checkLengthErrors(
+                                $reference,
+                                $translation,
+                                $reference_data['max_lengths'][$reference],
+                                $analysis_data['errors']['length']
+                            );
+                        }
                     }
                 } elseif ($translation === '') {
                     // Store in missing strings

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -59,8 +59,8 @@ class DotLangParser extends atoum\test
     public function testGetFileMissing()
     {
         $obj = new _DotLangParser();
-        $this
-            ->boolean($obj->getFile('fakefile', false))
+        _DotLangParser::$log_errors = false;
+        $this->boolean($obj->getFile('fakefile', false))
                 ->isFalse();
     }
 

--- a/views/countstrings.inc.php
+++ b/views/countstrings.inc.php
@@ -3,6 +3,10 @@ namespace Langchecker;
 
 use Transvision\Json;
 
+LangManager::$error_checking = false;
+DotLangParser::$extract_metadata = false;
+DotLangParser::$log_errors = false;
+
 $untranslated = [];
 $translated = [];
 $file_count = [];
@@ -15,20 +19,26 @@ foreach ($mozilla as $current_locale) {
     $file_count[$current_locale] = 0;
     foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
         $reference_locale = Project::getReferenceLocale($current_website);
+
         // Ignore reference language
         if ($current_locale == $reference_locale) {
             continue;
         }
+
         foreach (Project::getWebsiteFiles($current_website) as $current_filename) {
-            if (! Project::isSupportedLocale($current_website, $current_locale, $current_filename, $langfiles_subsets) ||
-                ! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename)) ||
-                in_array('obsolete', Project::getFileFlags($current_website, $current_filename, $current_locale))) {
-                /*
-                 * Ignore file for this locale if:
-                 * - It's not supported
-                 * - It doesn't exist
-                 * - It's marked as obsolete
-                 */
+
+            // File not supported
+            if (! Project::isSupportedLocale($current_website, $current_locale, $current_filename, $langfiles_subsets)) {
+                continue;
+            }
+
+            // File marked as obsolete
+            if (in_array('obsolete', Project::getFileFlags($current_website, $current_filename, $current_locale))) {
+                continue;
+            }
+
+            // File doesn't exist
+            if (! file_exists(Project::getLocalFilePath($current_website, $current_locale, $current_filename))) {
                 continue;
             }
 


### PR DESCRIPTION
- DotLangParser::extract_metadata static boolean property, allows a view to not extract any metadata when parsing lang files
- LangManager::error_checking static boolean property, allows a view to not look for errors in strings when parsing lang files
- Update main loop in DotLangParser::ParseFile() to test most common case first (translation exists)
- many small nitpicks and cleanups

Performance gains are mostly on the 'count' view (40% for me) but other views also benefit from a small speedup because of the code reorganization (~10%).