### PR TITLE
Faster Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+sudo: false
 language: php
 php:
   - 5.5
   - 5.6
 before_script:
   ## Composer
-  - composer install
+  - composer self-update
+  - composer install --no-interaction --prefer-source
   ## Travis configuration
   - cp config/settings.inc.php.ini config/settings.inc.php
 script:
@@ -20,3 +22,5 @@ notifications:
     template:
       - "%{repository} ; %{commit} (%{author}) : %{message} "
       - "Build details: %{build_url} ; changes: %{compare_url}"
+matrix:
+  fast_finish: true


### PR DESCRIPTION
- use sudo:false to force the use of Docker based Travis which is faster and can cache dependencies
- use prefer-source for composer because Travis is always hitting the github API limit and will fallback to that anyway
- use fast-finish:true in matrix section, allows to get informed that the build failed faster, if PHP 5.5 build failed and 5.6 build is not started, Travis will not wait for 5.5 to complete to send the failure notificatione