### PR TITLE
Add a tip about variable formats - fixes #311

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -48,25 +48,24 @@ class LangManager
     {
         /* Test if all Python variables are present, analyzing both
          * format %(var)s or %s, or 'escaped' percentage sign (%%) */
-        $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
-        preg_match_all($regex, $reference, $matches_reference);
-        preg_match_all($regex, $translation, $matches_locale);
+        $matches_reference = Utils::getPythonVariables($reference);
+        $matches_locale = Utils::getPythonVariables($translation);
 
-        if ($matches_reference[0] != $matches_locale[0]) {
+        if ($matches_reference != $matches_locale) {
             /* Locale and reference have different variables. Count
              * instances of each variable and compare them. */
-            $count_occurences = function ($value, $array) {
-                // Count occurences of $value in $array
+            $count_occurrences = function ($value, $array) {
+                // Count occurrences of $value in $array
                 $count_values = array_count_values($array);
-                $occurences = isset($count_values[$value]) ?
+                $occurrences = isset($count_values[$value]) ?
                               $count_values[$value] :
                               0;
 
-                return $occurences;
+                return $occurrences;
             };
 
-            foreach ($matches_reference[0] as $python_var) {
-                if ($count_occurences($python_var, $matches_locale[0]) != $count_occurences($python_var, $matches_reference[0])) {
+            foreach ($matches_reference as $python_var) {
+                if ($count_occurrences($python_var, $matches_locale) != $count_occurrences($python_var, $matches_reference)) {
                     $errors[$reference] = [
                         'text' => $translation,
                         'var'  => $python_var,
@@ -75,8 +74,8 @@ class LangManager
             }
 
             // Check if locale has extra variables
-            foreach ($matches_locale[0] as $python_var) {
-                if (! in_array($python_var, $matches_reference[0])) {
+            foreach ($matches_locale as $python_var) {
+                if (! in_array($python_var, $matches_reference)) {
                     $errors[$reference] = [
                         'text' => $translation,
                         'var'  => $python_var,

--- a/classes/Langchecker/Utils.php
+++ b/classes/Langchecker/Utils.php
@@ -124,18 +124,32 @@ class Utils
     }
 
     /**
+     * Get Python variables from a string. Checking for
+     * %(var)s, %s, and %% ('escaped' percentage sign)
+     *
+     * @param array $origin Original string
+     *
+     * @return array Python variables
+     */
+    public static function getPythonVariables($origin)
+    {
+        $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
+        preg_match_all($regex, $origin, $matches);
+
+        return $matches[0];
+    }
+
+    /**
      * Highlight Python variables in string
      *
      * @param array $origin Original string
      *
-     * @return string String withon Python variables marked with <em>
+     * @return string String with Python variables marked with <em>
      */
     public static function highlightPythonVar($origin)
     {
         $origin = htmlspecialchars($origin);
-        $regex = '#%(\([a-z0-9._-]+\)s|[s%])#';
-        preg_match_all($regex, $origin, $matches);
-        foreach ($matches[0] as $python_var) {
+        foreach (self::getPythonVariables($origin) as $python_var) {
             $origin = str_replace($python_var, "<em>${python_var}</em>", $origin);
         }
 

--- a/tests/units/Langchecker/Utils.php
+++ b/tests/units/Langchecker/Utils.php
@@ -138,6 +138,26 @@ class Utils extends atoum\test
                 ->isEqualTo($c);
     }
 
+    public function getPythonVariablesDP()
+    {
+        return [
+            ['test string', []],
+            ['test %(var)s', ['%(var)s']],
+            ['test %(var)s, %% and %s', ['%(var)s', '%%', '%s']],
+        ];
+    }
+
+    /**
+     * @dataProvider getPythonVariablesDP
+     */
+    public function testGetPythonVariables($a, $b)
+    {
+        $obj = new _Utils();
+        $this
+            ->array($obj->getPythonVariables($a))
+                ->isEqualTo($b);
+    }
+
     public function highlightPythonVarDP()
     {
         return [

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -172,6 +172,14 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
                                "     Example: </p><blockquote>;Plugins<br/>Plugins {ok}</blockquote>\n" .
                                "  </div>\n";
             }
+
+            if (LangManager::countErrors($locale_analysis['errors'], 'python')) {
+                $todo_files .= "  <div class='tip'>\n" .
+                               "    <p><strong>Tip:</strong> This file contains variables that can use the following formats:  \n" .
+                               "    </p><blockquote><strong>%(variable)s</strong>, <strong>%s</strong>, or <strong>%%</strong> (“escaped” percentage sign).</blockquote>\n" .
+                               "    <p>Make sure to keep these variables unchanged: don’t translate the text between brackets, or remove the “s” after the closing bracket.</p>\n" .
+                               "  </div>\n";
+            }
         }
     }
 


### PR DESCRIPTION
Would this work? Still have to actually write the tip itself in listsitesforlocale.inc.php instead of the current placeholder.

Displaying the tip if:
- We caught a Python var error in the file (since we currently don't display any advice about what's wrong)
- There are Python variables in untranslated strings

Not displaying it if there is no variables in the file, or if the variables are all in translated strings without error.