### PR TITLE
Read comment even if it's the first line of the file

### DIFF
--- a/classes/Langchecker/DotLangParser.php
+++ b/classes/Langchecker/DotLangParser.php
@@ -210,7 +210,7 @@ class DotLangParser
                 // I have a reference string
                 $reference = Utils::leftStrip($current_line, ';');
                 $j = $i - 1;
-                while ($j > 0) {
+                while ($j >= 0) {
                     // Stop if I find a line not starting with #
                     if (! Utils::startsWith($file_content[$j], '#')) {
                         break;

--- a/tests/testfiles/dotlang/test_comments.lang
+++ b/tests/testfiles/dotlang/test_comments.lang
@@ -1,0 +1,9 @@
+# I am a comment
+;Browser
+Navigateur
+
+
+# First comment
+# Second comment
+;Mail
+Courrier

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -150,6 +150,21 @@ class DotLangParser extends atoum\test
         $this
             ->integer($dotlang_data['max_lengths']['Save file wrong'])
                 ->isEqualTo(0);
+
+        // Test a second file only with comments
+        $test_file = TEST_FILES . 'dotlang/test_comments.lang';
+        $dotlang_data = $obj->parseFile($test_file, true);
+        $this
+            ->integer(count($dotlang_data['comments']))
+                ->isEqualTo(2);
+
+        $this
+            ->integer(count($dotlang_data['comments']['Mail']))
+                ->isEqualTo(2);
+
+        $this
+            ->string($dotlang_data['comments']['Mail'][1])
+                ->isEqualTo('Second comment');
     }
 
     public function testgetMetaTags()


### PR DESCRIPTION
We currently lose the first comment if the file starts with the comment and not with ´## NOTE: