### PR TITLE
Add Tags to analyzeLangFiles return value

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -131,9 +131,10 @@ class LangManager
             'Missing'    => [],
             'Obsolete'   => [],
             'errors'     => [
-                'python' => [],
                 'length' => [],
+                'python' => [],
             ],
+            'tags'       => [],
         ];
 
         foreach ($locale_data['strings'] as $reference => $translation) {
@@ -181,6 +182,11 @@ class LangManager
             if (! isset($locale_data['strings'][$reference])) {
                 $analysis_data['Missing'][] = $reference;
             }
+        }
+
+        // Copy tags if available
+        if (isset($locale_data['tags'])) {
+            $analysis_data['tags'] = $locale_data['tags'];
         }
 
         return $analysis_data;

--- a/views/errors.inc.php
+++ b/views/errors.inc.php
@@ -43,7 +43,6 @@ foreach ($mozilla as $current_locale) {
                 }
 
                 // Extract data from locale
-                $locale_data = LangManager::loadSource($current_website, $current_locale, $current_filename);
                 $locale_analysis = LangManager::analyzeLangFile($current_website, $current_locale, $current_filename, $reference_data);
 
                 // Check errors
@@ -109,8 +108,8 @@ foreach ($mozilla as $current_locale) {
                 }
 
                 // If locale has tags, display errors on unknown tags
-                if (isset($locale_data['tags'])) {
-                    $locale_file_tags = $locale_data['tags'];
+                if (isset($locale_analysis['tags'])) {
+                    $locale_file_tags = $locale_analysis['tags'];
                     if (isset($reference_data['tags'])) {
                         $extra_tags = array_diff($locale_file_tags, $reference_data['tags']);
                     } else {

--- a/views/globalstatus.inc.php
+++ b/views/globalstatus.inc.php
@@ -79,7 +79,6 @@ if ($website_data_source == 'lang') {
 
         // Read locale data
         $locale_analysis = LangManager::analyzeLangFile($current_website, $current_locale, $current_filename, $reference_data);
-        $locale_data = LangManager::loadSource($current_website, $current_locale, $current_filename);
 
         $todo = count($locale_analysis['Identical']) + count($locale_analysis['Missing']);
         $total = $todo + count($locale_analysis['Translated']);
@@ -107,8 +106,8 @@ if ($website_data_source == 'lang') {
         }
 
         // Tags
-        if (isset($locale_data['tags'])) {
-            $locale_tags = $locale_data['tags'];
+        if (isset($locale_analysis['tags'])) {
+            $locale_tags = $locale_analysis['tags'];
             sort($locale_tags);
             $json_data[$current_filename][$current_locale]['tags'] = $locale_tags;
             // Remove _promo from tags


### PR DESCRIPTION
In the Errors view we’re parsing each localized file twice just to get tags.

This cuts the time needed to display this page in half.