### PR TITLE
Report extra strings in lang files as errors

### DIFF
--- a/classes/Langchecker/LangManager.php
+++ b/classes/Langchecker/LangManager.php
@@ -131,8 +131,9 @@ class LangManager
             'Missing'    => [],
             'Obsolete'   => [],
             'errors'     => [
-                'length' => [],
-                'python' => [],
+                'ignoredstrings' => [],
+                'length'         => [],
+                'python'         => [],
             ],
             'tags'       => [],
         ];
@@ -166,6 +167,9 @@ class LangManager
                                 $analysis_data['errors']['length']
                             );
                         }
+
+                        // Copy ignored strings errors to data analysis
+                        $analysis_data['errors']['ignoredstrings'] = $locale_data['errors']['ignoredstrings'];
                     }
                 } elseif ($translation === '') {
                     // Store in missing strings

--- a/media/css/langchecker.css
+++ b/media/css/langchecker.css
@@ -216,6 +216,7 @@ tr.tabletotals th {
 .file_container {
     background-color: #fff;
     padding: 5px;
+    min-height: 140px;
 }
 
 .file_container .filename {

--- a/tests/testfiles/dotlang/it/page.lang
+++ b/tests/testfiles/dotlang/it/page.lang
@@ -46,6 +46,7 @@ Seconda stringa con %(num)s etichette
 
 ;Obsolete string
 Stringa obsoleta
+seconda linea
 
 
 ;Third string with %s tags

--- a/tests/testfiles/dotlang/toto.lang
+++ b/tests/testfiles/dotlang/toto.lang
@@ -11,7 +11,8 @@ Navigateur
 
 ;Mail
 Courrier
-
+2nd line
+3rd line
 
 
 

--- a/tests/units/Langchecker/DotLangParser.php
+++ b/tests/units/Langchecker/DotLangParser.php
@@ -25,6 +25,8 @@ class DotLangParser extends atoum\test
                     'Navigateur',
                     ';Mail',
                     'Courrier',
+                    '2nd line',
+                    '3rd line',
                     '# another comment',
                     ';Hello',
                     'Bonjour',
@@ -97,6 +99,11 @@ class DotLangParser extends atoum\test
             ->boolean(isset($dotlang_data['duplicates']))
                 ->isFalse();
 
+        // Check multiline strings errors
+        $this
+            ->array($dotlang_data['errors']['ignoredstrings'])
+                ->isEqualTo(['2nd line', '3rd line']);
+
         // Check translation of one string
         $this
             ->string($dotlang_data['strings']['Hello'])
@@ -130,6 +137,11 @@ class DotLangParser extends atoum\test
         $this
             ->boolean(in_array('Hello', $dotlang_data['duplicates']))
                 ->isTrue();
+
+        // Check multiline strings errors
+        $this
+            ->array($dotlang_data['errors']['ignoredstrings'])
+                ->isEqualTo(['2nd line', '3rd line']);
 
         // Check bound tags
         $this

--- a/tests/units/Langchecker/LangManager.php
+++ b/tests/units/Langchecker/LangManager.php
@@ -86,19 +86,23 @@ class LangManager extends atoum\test
 
         $this
             ->integer($obj->countErrors($analysis_data['errors'], 'all'))
-                ->isEqualTo(6);
+                ->isEqualTo(7);
 
         $this
             ->integer($obj->countErrors($analysis_data['errors']))
-                ->isEqualTo(6);
-
-        $this
-            ->integer($obj->countErrors($analysis_data['errors'], 'python'))
-                ->isEqualTo(5);
+                ->isEqualTo(7);
 
         $this
             ->integer($obj->countErrors($analysis_data['errors'], 'length'))
                 ->isEqualTo(1);
+
+        $this
+            ->integer($obj->countErrors($analysis_data['errors'], 'ignoredstrings'))
+                ->isEqualTo(1);
+
+        $this
+            ->integer($obj->countErrors($analysis_data['errors'], 'python'))
+                ->isEqualTo(5);
 
         $this
             ->integer($obj->countErrors($analysis_data['errors'], 'random'))

--- a/views/errors.inc.php
+++ b/views/errors.inc.php
@@ -87,6 +87,20 @@ foreach ($mozilla as $current_locale) {
                         }
                         $locale_htmloutput .= "    </ul>\n";
                     }
+
+                    if (LangManager::countErrors($locale_analysis['errors'], 'ignoredstrings')) {
+                        if (! $website_with_errors) {
+                            $website_with_errors = true;
+                            $locale_htmloutput .= $opening_div;
+                        }
+                        $locale_htmloutput .= "\n    <h3>{$current_filename}</h3><p>The following strings will be ignored:</p>\n";
+                        $locale_htmloutput .= "    <ul>\n";
+                        foreach ($locale_analysis['errors']['ignoredstrings'] as $stringid) {
+                            $locale_htmloutput .= '<li>' . htmlspecialchars($stringid) . "</li>\n";
+                        }
+                        $locale_htmloutput .= "    </ul>\n";
+                        $locale_htmloutput .= "<p>This is usually caused by tools trying to store multiline strings (not supported in .lang files).</p>\n";
+                    }
                 }
 
                 // Check if the lang file is not in UTF-8 or US-ASCII

--- a/views/listsitesforlocale.inc.php
+++ b/views/listsitesforlocale.inc.php
@@ -161,6 +161,16 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
                     }
                     $todo_files .= "    </ul>\n";
                 }
+
+                if (LangManager::countErrors($locale_analysis['errors'], 'ignoredstrings')) {
+                    $todo_files .= "\n    <h3>The following strings will be ignored:</h3>\n";
+                    $todo_files .= "    <ul>\n";
+                    foreach ($locale_analysis['errors']['ignoredstrings'] as $stringid) {
+                        $todo_files .= '<li>' . htmlspecialchars($stringid) . "</li>\n";
+                    }
+                    $todo_files .= "    </ul>\n";
+                    $todo_files .= "<p>This is usually caused by tools trying to store multiline strings (not supported in .lang files).</p>\n";
+                }
             }
             $todo_files .= "  </div>\n";
 


### PR DESCRIPTION
Pootle and Pontoon sometimes try to store multiline strings in .lang files (localizers create new lines in the editor). Sometimes localizers forget to remove the English “translation” too.

While lang_update already removes them, it’s useful to have a check in the errors page.