### PR TITLE
Optin redesign

### DIFF
--- a/app/classes/Langchecker/Bugzilla.php
+++ b/app/classes/Langchecker/Bugzilla.php
@@ -27,19 +27,9 @@ class Bugzilla extends _Bugzilla
     public static function getNewBugLink($locale, $bugzilla_locale, $bug_type, $files)
     {
         if ($bug_type == 'opt-in') {
-            // Bug to request optional pages
-            if (count($files) > 1) {
-                // Filing a bug for multiple files.
-                $bug_title = "[l10n: {$locale}] Add opt-in pages to '{$locale}'";
-                $bug_body = "Please add '{$locale}' to the list of supported locales for the following files on www.mozilla.org:\n";
-                foreach ($files as $filename) {
-                    $bug_body .= "* {$filename}\n";
-                }
-            } else {
-                // Filing a bug for a single file.
-                $bug_title = "[l10n: {$locale}] Add '{$locale}' to the list of supported locales for {$files[0]}";
-                $bug_body = "Please add '{$locale}' to the list of supported locales for {$files[0]} on www.mozilla.org";
-            }
+            // Bug to request optional pages. The bug body will be filed at run-time with JS
+            $bug_title = "[l10n: {$locale}] Add opt-in pages to '{$locale}'";
+            $bug_body = '';
         } else {
             // Bug to request upload of updated files to GitHub
             $bug_title = "[l10n: {$locale}] Updated file '{$files[0]}' for GitHub repository";
@@ -48,7 +38,6 @@ class Bugzilla extends _Bugzilla
 
         $bug_link = 'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com' .
                     '&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW' .
-                    '&comment=' . urlencode($bug_body) .
                     '&component=L10N&contenttypeentry=&contenttypemethod=autodetect' .
                     '&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X' .
                     '&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug' .
@@ -56,7 +45,8 @@ class Bugzilla extends _Bugzilla
                     '&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com' .
                     '&rep_platform=All&short_desc=' . urlencode($bug_title) .
                     '&target_milestone=---&version=Development%2FStaging' .
-                    '&format=__default__&cf_locale=' . $bugzilla_locale;
+                    '&format=__default__&cf_locale=' . $bugzilla_locale .
+                    '&comment=' . urlencode($bug_body);
 
         return $bug_link;
     }

--- a/app/controllers/optin.php
+++ b/app/controllers/optin.php
@@ -36,7 +36,7 @@ foreach ($optin_pages as $current_filename => $supported_locales) {
     }
 
     $files_list[$current_filename] = [
-        'action'   => $locale_included ? '' : Bugzilla::getNewBugLink($current_locale, $bugzilla_locale, 'opt-in', [$current_filename]),
+        'opted_in' => $locale_included,
         'deadline' => isset($deadline[$current_filename]) ? $deadline[$current_filename] : '-',
         'page_url' => Project::getLocalizedURL($reference_data, $current_locale),
         'status'   => $locale_included ? 'yes' : 'no',

--- a/app/templates/optin.twig
+++ b/app/templates/optin.twig
@@ -1,10 +1,19 @@
 {% extends 'default.twig' %}
 
+{% block js_files %}
+    <script src="{{ assets_folder }}/js/optin.js"></script>
+{% endblock %}
+
 {% block body %}
     <h1>List of optional pages for <span>{{ locale }}</span></h1>
     {% if files_list|length == 0 %}
         <p>There are no optional pages available at the moment.</p>
     {% else %}
+        <div id="noscript_warning">
+            Please enable JavaScript. This page won't work properly without it.
+        </div>
+        <p>Use the last column on the right to select the pages you want to enable for your locale.<br>
+           Then click the button at the bottom of the column to file a bug (you will need an account on Bugzilla).</p>
         <table class="optinpages">
             <thead>
                 <tr>
@@ -14,7 +23,7 @@
                     <th>Words</th>
                     <th>Deadline</th>
                     <th>Opted-in</th>
-                    <th>Actions</th>
+                    <th>Opt-in</th>
                 </tr>
             </thead>
             <tbody>
@@ -27,18 +36,27 @@
                     <td>{{ file_data.deadline }}</td>
                     <td class='optin_status'><span class="{{ file_data.status }}">{{ file_data.status }}</span></td>
                     <td class='optin_actions'>
-                    {% if file_data.action != '' %}
-                        <a href="{{ file_data.action }}" class="table_small_link" title="File a bug to request this page">Opt-in</a>
+                    {% if file_data.opted_in %}
+                        ✓
                     {% else %}
-                        –
+                        <input type="checkbox" class="optin_checkbox" value="{{ filename }}">
                     {% endif %}
                     </td>
                 </tr>
             {% endfor %}
             </tbody>
+            {% if available_optins > 0 %}
+                <tfoot>
+                    <tr>
+                        <td colspan="6"></td>
+                        <td>
+                            <input type="hidden" id="base_url" value="{{ optin_url }}">
+                            <input type="hidden" id="locale_code" value="{{ locale }}">
+                            <input type="submit" id="bugzilla_button" value="OPT-IN!" disabled="disabled">
+                        </td>
+                    </tr>
+                </tfoot>
+            {% endif %}
         </table>
-        {% if available_optins > 0 %}
-            <p>You can also <a href="{{ optin_url }}">file a bug to opt-in for all pages</a> currently available for your locale ({{ available_optins }})</p>
-        {% endif %}
     {% endif %}
 {% endblock %}

--- a/tests/units/Langchecker/Bugzilla.php
+++ b/tests/units/Langchecker/Bugzilla.php
@@ -16,21 +16,14 @@ class Bugzilla extends atoum\test
                 'it%20%2F%20Italian',
                 'opt-in',
                 ['firefox/new.lang'],
-                'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW&comment=Please+add+%27it%27+to+the+list+of+supported+locales+for+firefox%2Fnew.lang+on+www.mozilla.org&component=L10N&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com&rep_platform=All&short_desc=%5Bl10n%3A+it%5D+Add+%27it%27+to+the+list+of+supported+locales+for+firefox%2Fnew.lang&target_milestone=---&version=Development%2FStaging&format=__default__&cf_locale=it%20%2F%20Italian',
-            ],
-            [
-                'it',
-                'it%20%2F%20Italian',
-                'opt-in',
-                ['firefox/new.lang', 'firefox/dnt.lang'],
-                'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW&comment=Please+add+%27it%27+to+the+list+of+supported+locales+for+the+following+files+on+www.mozilla.org%3A%0A%2A+firefox%2Fnew.lang%0A%2A+firefox%2Fdnt.lang%0A&component=L10N&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com&rep_platform=All&short_desc=%5Bl10n%3A+it%5D+Add+opt-in+pages+to+%27it%27&target_milestone=---&version=Development%2FStaging&format=__default__&cf_locale=it%20%2F%20Italian',
+                'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW&component=L10N&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com&rep_platform=All&short_desc=%5Bl10n%3A+it%5D+Add+opt-in+pages+to+%27it%27&target_milestone=---&version=Development%2FStaging&format=__default__&cf_locale=it%20%2F%20Italian&comment=',
             ],
             [
                 'fr',
                 'fr%20%2F%20French',
                 'upload',
                 ['firefox/new.lang'],
-                'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW&comment=%28Attach+your+updated+firefox%2Fnew.lang+file+to+this+bug+or+indicate+the+changeset+of+your+commit+in+GitHub%29&component=L10N&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com&rep_platform=All&short_desc=%5Bl10n%3A+fr%5D+Updated+file+%27firefox%2Fnew.lang%27+for+GitHub+repository&target_milestone=---&version=Development%2FStaging&format=__default__&cf_locale=fr%20%2F%20French',
+                'https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=francesco.lodolo%40gmail.com&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=normal&bug_status=NEW&component=L10N&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-4=X&flag_type-418=X&flag_type-419=X&flag_type-506=X&flag_type-507=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=www.mozilla.org&qa_contact=pascalc%40gmail.com&rep_platform=All&short_desc=%5Bl10n%3A+fr%5D+Updated+file+%27firefox%2Fnew.lang%27+for+GitHub+repository&target_milestone=---&version=Development%2FStaging&format=__default__&cf_locale=fr%20%2F%20French&comment=%28Attach+your+updated+firefox%2Fnew.lang+file+to+this+bug+or+indicate+the+changeset+of+your+commit+in+GitHub%29',
             ],
         ];
     }

--- a/web/assets/css/langchecker.css
+++ b/web/assets/css/langchecker.css
@@ -361,6 +361,29 @@ div.tip blockquote {
     color: #92cc6e;
 }
 
+#bugzilla_button {
+    margin: 5px 2px;
+    padding: 5px;
+    border: 1px solid #9e988b;
+    border-radius: 0.25em;
+    box-shadow: 2px 2px 3px #b8b1a2;
+}
+
+#bugzilla_button:hover {
+    background: #b8b1a2;
+}
+
+#bugzilla_button:active {
+    color: #fff;
+    background: #706c64;
+}
+
+#noscript_warning {
+    color: #f2294b;
+    font-weight: bold;
+    padding: 10px 0;
+}
+
 /* Translate page */
 
 .tag,

--- a/web/assets/js/base.js
+++ b/web/assets/js/base.js
@@ -1,5 +1,5 @@
 function showhide(id) {
-    table = document.getElementById('table' + id);
+    var table = document.getElementById('table' + id);
     if (table.style.display == '') {
         table.style.display='none';
     } else {

--- a/web/assets/js/optin.js
+++ b/web/assets/js/optin.js
@@ -1,0 +1,64 @@
+function getSelectedPages() {
+    // Return array of selected pages
+    var checkboxes = document.getElementsByClassName('optin_checkbox');
+    var list = [];
+
+    for(var i=0, n=checkboxes.length; i<n; i++) {
+        if (checkboxes[i].checked) {
+            list.push(checkboxes[i].value);
+        }
+    }
+
+    return list;
+};
+
+window.onload = function() {
+    var bugzilla_button = document.getElementById('bugzilla_button');
+
+    // Hide warning for disabled JavaScript
+    var noscript_warning = document.getElementById('noscript_warning');
+    noscript_warning.style.display = 'none';
+
+    if (bugzilla_button) {
+        // Add listener only if the button is available,
+        // i.e. there are pages available for opt-in
+        bugzilla_button.addEventListener('click', function() {
+            var base_url = document.getElementById('base_url');
+            var locale = document.getElementById('locale_code');
+            var message;
+            var selected_pages = getSelectedPages();
+
+            if (selected_pages.length > 0) {
+                message = 'Please add ' + locale.value + ' to the list of ' +
+                          'supported locales for the following files on ' +
+                          'www.mozilla.org:\n';
+                for(var i=0, n=selected_pages.length; i<n; i++) {
+                    message += '* ' + selected_pages[i] + '\n';
+                }
+                var bugzilla_url = base_url.value + encodeURI(message);
+                var win = window.open(bugzilla_url, '_blank');
+                win.focus();
+            } else {
+                alert('Please select at least one page to proceed.');
+            }
+        });
+
+        // Associate listener to checkboxes
+        var checkboxes = document.getElementsByClassName('optin_checkbox');
+        for(var i=0, n=checkboxes.length; i<n; i++) {
+            checkboxes[i].addEventListener('click', function() {
+                if (this.checked) {
+                    // Make sure the button is enabled
+                    bugzilla_button.removeAttribute('disabled');
+                } else {
+                    // Check if the button should be disabled
+                    var selected_pages = getSelectedPages();
+
+                    if (selected_pages.length == 0) {
+                        bugzilla_button.setAttribute('disabled', 'disabled');
+                    }
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Use checkboxes to select pages, use a button to open the URL

Reason for the redesign: nobody uses the link at the bottom of the page, I keep receiving multiple bugs filed at the same time from the same localizer.

I asked them and the link at the bottom is either unclear or not visible.

This is based on #401, so it will need to be rebased or fixed after that. Filing a PR to avoid forgetting about it.