### PR TITLE
Provide a faster way to get last update timestamp from Git log

### DIFF
--- a/app/classes/Langchecker/RawManager.php
+++ b/app/classes/Langchecker/RawManager.php
@@ -1,6 +1,8 @@
 <?php
 namespace Langchecker;
 
+use Cache\Cache;
+
 /**
  * RawManager class
  *
@@ -17,58 +19,61 @@ class RawManager
     /**
      * Compare reference and localized raw file
      *
-     * @param array  $website      Website data
-     * @param string $locale       Locale to analyze
-     * @param string $filename     File to analyze
-     * @param string $content_only Compare only content, not timestamps
+     * @param array  $website  Website data
+     * @param string $locale   Locale to analyze
+     * @param string $filename File to analyze
      *
      * @return array Results from comparison
      */
-    public static function compareRawFiles($website, $locale, $filename, $content_only = true)
+    public static function compareRawFiles($website, $locale, $filename)
     {
         $results = [];
 
-        // Store reference file hash and last update date
+        /* Check if we already analyzed and cached the log for this website.
+         * If not, analyze and cache it
+         */
+        $website_name = Project::getWebsiteName($website);
+        $cache_id = "raw_timestamps_{$website_name}";
+        if (! $raw_timestamps = Cache::getKey($cache_id)) {
+            $raw_timestamps = self::getGitRawTimestamps(Project::getWebsiteLocalRepository($website));
+            Cache::setKey($cache_id, $raw_timestamps);
+        }
+
         $reference_locale = Project::getReferenceLocale($website);
         $reference_filename = Project::getLocalFilePath($website, $reference_locale, $filename);
         if (file_exists($reference_filename)) {
+            // Store reference file hash and last update date
             $reference_content = sha1_file($reference_filename);
             $results['reference_exists'] = true;
             $results['reference_url'] = Project::getPublicFilePath($website, $reference_locale, $filename);
-            if ($content_only) {
-                // Use local timestamp for reference
-                $results['reference_lastupdate'] = filemtime($reference_filename);
+
+            if (isset($raw_timestamps[$reference_filename])) {
+                $results['reference_lastupdate'] = $raw_timestamps[$reference_filename];
             } else {
-                $results['reference_lastupdate'] = Utils::getGitCommitTimestamp(
-                    $reference_filename,
-                    Project::getWebsiteLocalRepository($website)
-                );
+                // No data available from git log, use local filestamp
+                $results['reference_lastupdate'] = filemtime($reference_filename);
             }
         } else {
             $results['reference_exists'] = false;
             $results['cmp_result'] = 'missing_reference';
         }
 
-        // Generate locale file hash and last update date
         $locale_filename = Project::getLocalFilePath($website, $locale, $filename);
         if (file_exists($locale_filename)) {
+            // Store locale file hash and last update date
             $locale_content = sha1_file($locale_filename);
             $results['locale_exists'] = true;
             $results['locale_url'] = Project::getPublicFilePath($website, $locale, $filename);
-            if ($content_only) {
-                // Use local timestamp for reference
-                $results['locale_lastupdate'] = filemtime($locale_filename);
+            if (isset($raw_timestamps[$locale_filename])) {
+                $results['locale_lastupdate'] = $raw_timestamps[$locale_filename];
             } else {
-                $results['locale_lastupdate'] = Utils::getGitCommitTimestamp(
-                    $locale_filename,
-                    Project::getWebsiteLocalRepository($website)
-                );
+                // No data available from git log, use local filestamp
+                $results['locale_lastupdate'] = filemtime($locale_filename);
             }
-
             if ($results['reference_exists']) {
                 if ($locale_content == $reference_content) {
                     $results['cmp_result'] = 'untranslated';
-                } elseif (! $content_only && $results['reference_lastupdate'] > $results['locale_lastupdate']) {
+                } elseif ($results['reference_lastupdate'] > $results['locale_lastupdate']) {
                     // I check dates only if content is not identical
                     $results['cmp_result'] = 'outdated';
                 } else {
@@ -81,5 +86,73 @@ class RawManager
         }
 
         return $results;
+    }
+
+    /**
+     * Run git log in shell, return an array of files with their last update
+     * timestamp
+     *
+     * @param string $path Path to the Git repository to analyze
+     *
+     * @return array Files with their last update timestamp
+     *
+     */
+    public static function getGitRawTimestamps($path)
+    {
+        exec(
+            "git --work-tree={$path} --git-dir={$path}.git log --pretty=format:'%cd' --name-only --follow -- */*.txt 2>/dev/null",
+            $git_log,
+            $return_code
+        );
+
+        if (empty($git_log) || $return_code) {
+            return [];
+        }
+
+        return self::parseGitLog($path, $git_log);
+    }
+
+    /**
+     * Analyze git log and return an array of files with their last update
+     * timestamp
+     *
+     * Output from the git log command is in the format
+     * DATE
+     * [list of files, one filename on each line]
+     * [empty line]
+     *
+     * @param string $path    Path to the Git repository to analyze
+     * @param string $git_log Git log
+     *
+     * @return array Files with their last update timestamp
+     *
+     */
+    public static function parseGitLog($path, $git_log)
+    {
+        $file_timestamps = [];
+        for ($i = 0, $lines = count($git_log); $i < $lines; $i++) {
+            // First line is the timestamp
+            $timestamp = $git_log[$i];
+
+            /* We need an exception to ignore the change of reference locale from
+             * en-GB to en-US on Jan 15 2015.
+             */
+            if ($timestamp == 'Thu Jan 15 13:46:56 2015 +0000') {
+                $timestamp = 'Thu Oct 9 17:27:57 2014 +0000';
+            }
+
+            // Following lines are filenames, there is at least one
+            $files_in_commit = [];
+            $current_line = $git_log[++$i];
+            while ($current_line != '' && $i < $lines - 1) {
+                $file_name = $path . $current_line;
+                if (! isset($file_timestamps[$file_name])) {
+                    $file_timestamps[$file_name] = (new \DateTime($timestamp))->getTimestamp();
+                }
+                $current_line = $git_log[++$i];
+            }
+        }
+
+        return $file_timestamps;
     }
 }

--- a/app/classes/Langchecker/Utils.php
+++ b/app/classes/Langchecker/Utils.php
@@ -177,42 +177,6 @@ class Utils
     }
 
     /**
-     * Get the timestamp of a Git commit for a file
-     *
-     * @param string $filename File to analyze
-     * @param string $git_repo Path to the local Git repository
-     *
-     * @return int Timestamp of last commit from Git,
-     *             or local if that fails
-     */
-    public static function getGitCommitTimestamp($filename, $git_repo)
-    {
-        exec(
-            "git --work-tree={$git_repo} --git-dir={$git_repo}/.git log --follow -2 --format=%cd {$filename} 2>/dev/null",
-            $output,
-            $return_code
-        );
-
-        if ($return_code) {
-            return filemtime($filename);
-        }
-
-        /* On January 15 2015 we moved our reference content from the en-GB
-         * folder to the en-US folder. Unlike svn, Git considers that this is
-         * a file change, so we need to ignore this date otherwise many
-         * translations would be marked as incorrect. That's why we took 2 items
-         * in the file history.
-         */
-        if ($output[0] == 'Thu Jan 15 13:46:56 2015 +0000') {
-            $reference_date = $output[1];
-        } else {
-            $reference_date = $output[0];
-        }
-
-        return (new \DateTime($reference_date))->getTimestamp();
-    }
-
-    /**
      * Print error, quit application if requested
      *
      * @param string $message Message to display

--- a/tests/testfiles/misc/git_log.txt
+++ b/tests/testfiles/misc/git_log.txt
@@ -1,0 +1,98 @@
+Wed Nov 4 23:09:04 2015 +0800
+zh-TW/templates/mozorg/emails/addons.txt
+
+Wed Nov 4 23:07:05 2015 +0800
+zh-TW/templates/mozorg/emails/coding.txt
+
+Wed Nov 4 23:05:02 2015 +0800
+zh-TW/templates/mozorg/emails/localization.txt
+
+Wed Oct 21 22:44:00 2015 +0200
+de/templates/mozorg/emails/other.txt
+
+Sat Oct 10 07:27:42 2015 +0200
+it/templates/mozorg/contribute-2015/activism.txt
+it/templates/mozorg/contribute-2015/coding_addons.txt
+it/templates/mozorg/contribute-2015/coding_cloud.txt
+it/templates/mozorg/contribute-2015/coding_firefox.txt
+it/templates/mozorg/contribute-2015/coding_firefoxos.txt
+it/templates/mozorg/contribute-2015/coding_marketplace.txt
+it/templates/mozorg/contribute-2015/coding_webcompat.txt
+it/templates/mozorg/contribute-2015/coding_webdev.txt
+it/templates/mozorg/contribute-2015/dontknow.txt
+it/templates/mozorg/contribute-2015/education_fellowships.txt
+it/templates/mozorg/contribute-2015/education_hive.txt
+it/templates/mozorg/contribute-2015/education_sciencelab.txt
+it/templates/mozorg/contribute-2015/education_webmaker.txt
+it/templates/mozorg/contribute-2015/l10n_product.txt
+it/templates/mozorg/contribute-2015/l10n_tools.txt
+it/templates/mozorg/contribute-2015/l10n_web.txt
+it/templates/mozorg/contribute-2015/qa_addons.txt
+it/templates/mozorg/contribute-2015/qa_general.txt
+it/templates/mozorg/contribute-2015/qa_marketplace.txt
+it/templates/mozorg/contribute-2015/qa_webcompat.txt
+it/templates/mozorg/contribute-2015/sumo_sumo.txt
+it/templates/mozorg/contribute-2015/sumo_webcompat.txt
+it/templates/mozorg/contribute-2015/writing_addons.txt
+it/templates/mozorg/contribute-2015/writing_journalism.txt
+it/templates/mozorg/contribute-2015/writing_marketplace.txt
+it/templates/mozorg/contribute-2015/writing_social.txt
+it/templates/mozorg/contribute-2015/writing_txt_devs.txt
+it/templates/mozorg/contribute-2015/writing_txt_users.txt
+
+Fri Sep 25 11:49:39 2015 +0000
+cy/templates/mozorg/contribute-2015/generic_template.txt
+
+Thu Sep 24 08:13:13 2015 +0000
+de/templates/mozorg/emails/other.txt
+
+Wed Aug 12 12:10:09 2015 +0000
+en-US/templates/mozorg/emails/documentation.txt
+en-US/templates/mozorg/emails/infos.txt
+en-US/templates/mozorg/emails/localization.txt
+
+Thu Jan 15 13:46:56 2015 +0000
+en-US/templates/mozorg/contribute-2015/READ_ME.txt
+en-US/templates/mozorg/contribute-2015/activism.txt
+en-US/templates/mozorg/contribute-2015/coding_addons.txt
+en-US/templates/mozorg/contribute-2015/coding_cloud.txt
+en-US/templates/mozorg/contribute-2015/coding_firefox.txt
+en-US/templates/mozorg/contribute-2015/coding_firefoxos.txt
+en-US/templates/mozorg/contribute-2015/coding_marketplace.txt
+en-US/templates/mozorg/contribute-2015/coding_webcompat.txt
+en-US/templates/mozorg/contribute-2015/coding_webdev.txt
+en-US/templates/mozorg/contribute-2015/dontknow.txt
+en-US/templates/mozorg/contribute-2015/education_fellowships.txt
+en-US/templates/mozorg/contribute-2015/education_hive.txt
+en-US/templates/mozorg/contribute-2015/education_sciencelab.txt
+en-US/templates/mozorg/contribute-2015/education_webmaker.txt
+en-US/templates/mozorg/contribute-2015/generic_template.txt
+en-US/templates/mozorg/contribute-2015/l10n_product.txt
+en-US/templates/mozorg/contribute-2015/l10n_tools.txt
+en-US/templates/mozorg/contribute-2015/l10n_web.txt
+en-US/templates/mozorg/contribute-2015/qa_addons.txt
+en-US/templates/mozorg/contribute-2015/qa_general.txt
+en-US/templates/mozorg/contribute-2015/qa_marketplace.txt
+en-US/templates/mozorg/contribute-2015/qa_webcompat.txt
+en-US/templates/mozorg/contribute-2015/sumo_sumo.txt
+en-US/templates/mozorg/contribute-2015/sumo_webcompat.txt
+en-US/templates/mozorg/contribute-2015/writing_addons.txt
+en-US/templates/mozorg/contribute-2015/writing_journalism.txt
+en-US/templates/mozorg/contribute-2015/writing_marketplace.txt
+en-US/templates/mozorg/contribute-2015/writing_social.txt
+en-US/templates/mozorg/contribute-2015/writing_txt_devs.txt
+en-US/templates/mozorg/contribute-2015/writing_txt_users.txt
+en-US/templates/mozorg/emails/addons.txt
+en-US/templates/mozorg/emails/coding.txt
+en-US/templates/mozorg/emails/design.txt
+en-US/templates/mozorg/emails/documentation.txt
+en-US/templates/mozorg/emails/education.txt
+en-US/templates/mozorg/emails/issues.txt
+en-US/templates/mozorg/emails/localization.txt
+en-US/templates/mozorg/emails/marketing.txt
+en-US/templates/mozorg/emails/marketplace.txt
+en-US/templates/mozorg/emails/other.txt
+en-US/templates/mozorg/emails/qa.txt
+en-US/templates/mozorg/emails/suggestions.txt
+en-US/templates/mozorg/emails/support.txt
+en-US/templates/mozorg/emails/webdev.txt

--- a/tests/units/Langchecker/RawManager.php
+++ b/tests/units/Langchecker/RawManager.php
@@ -48,9 +48,45 @@ class RawManager extends atoum\test
         touch($referencefile);
         touch(_Project::getLocalFilePath($website, 'it', $filename), $timestamp);
 
-        $file_analysis = $obj->compareRawFiles($website, 'it', $filename, false);
+        $file_analysis = $obj->compareRawFiles($website, 'it', $filename);
         $this
             ->string($file_analysis['cmp_result'])
                 ->isEqualTo('outdated');
+    }
+
+    public function parseGitLogDP()
+    {
+        return [
+            [
+                'test/repo/zh-TW/templates/mozorg/emails/addons.txt',
+                1446649744,
+            ],
+            [
+                'test/repo/it/templates/mozorg/contribute-2015/writing_txt_users.txt',
+                1444454862,
+            ],
+            [
+                'test/repo/en-US/templates/mozorg/emails/infos.txt',
+                1439381409,
+            ],
+            [
+                'test/repo/en-US/templates/mozorg/contribute-2015/l10n_tools.txt',
+                1412875677,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseGitLogDP
+     */
+    public function testparseGitLog($a, $b)
+    {
+        $obj = new _RawManager();
+        $git_log = file(TEST_FILES . 'misc/git_log.txt', FILE_IGNORE_NEW_LINES);
+        $timestamps = $obj->parseGitLog('test/repo/', $git_log);
+
+        $this
+            ->integer($timestamps[$a])
+                ->isEqualTo($b);
     }
 }


### PR DESCRIPTION
Again, based on #401 so will need rebase after that's reviewed and fixed.

Fixes #406: the current implementation takes about 200ms for each file. That's 10.8s on a page like Italian (27 files x 2), even caching en-US results is not enough.

The idea is to get timestamps for all files calling `git log` only once, and cache the result. Even without cache (first load), the Italian page loads in less than 3 seconds. Second load goes back to 0.2s
