### PR TITLE
Reorganize sources, add script to update repos

### DIFF
--- a/app/config/settings.inc.php.ini
+++ b/app/config/settings.inc.php.ini
@@ -1,18 +1,9 @@
 <?php
 
-// Paths must end with slash
-$repo1  = '/localpath/to/git/www.mozilla.org/';
-$repo2  = '/localpath/to/svn/l10n-misc/fx36start/locale/';
-$repo3  = '/localpath/to/svn/l10n-misc/surveys/';
-$repo4  = '/localpath/to/svn/l10n-misc/marketing/';
-$repo5  = '/localpath/to/git/fhr-l10n/';
-$repo6  = '/localpath/to/svn/granary/slogans/';
-$repo7  = '/localpath/to/git/engagement-l10n/';
-$repo8  = '/localpath/to/svn/l10n-misc/add-ons/';
-$repo9  = '/localpath/to/svn/l10n-misc/firefoxupdater/';
-$repo10 = '/localpath/to/svn/l10n-misc/firefoxos-marketing/';
-$repo11 = ''; // Free to use for new projects, was originally used for Tiles
-$repo12 = '/localpath/to/git/appstores/';
+/* By default all repositories will be stored in this path.
+ * Important: path must end with slash.
+ */
+$local_storage = '/localpath/to/repositories/';
 
 // Path to local clone of Locamotion's repo
 $locamotion_repo  = '/localpath/to/git/mozilla-lang/';
@@ -25,3 +16,12 @@ $locamotion_repo  = '/localpath/to/git/mozilla-lang/';
 $webroot_folder = '/langchecker/';
 
 const DEBUG = false;
+
+/* It is possible to override local paths for specific repositories
+ * by creating an array called $override_local with the following structure.
+ * Repository IDs can be found in sources.inc.php
+ *
+ * $override_local = [
+ *     'www.mozilla.org' => '/full/path/to/your/clone',
+ * ];
+ */

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -119,10 +119,23 @@ $repositories = [
 ];
 
 /*
- * If a file is not listed in $lang_flags, it's assumed to be non critical
- * for all locales.
+ * Flags are defined for each website later in the file. For each file in
+ * a website it's possible to specify flags, and for which locales these flags
+ * are valid.
+ * Currently we're using flags to tag files as critical, obsolete and opt-in.
+ *
+ * If a file is not listed, it's assumed to be non critical for all locales.
  * If a flag is valid for all locales, set it to ['all']. If it's not,
  * set the flag to the array of locales.
+ *
+ * Example (a file critical for French but opt-in for all other locales):
+ * $lang_flags['website_name'] = [
+ *     'file.lang' => [
+ *         'critical' => ['fr'],
+ *         'opt-in'   => ['all'],
+ *     ],
+ * ];
+ *
  */
 $lang_flags = [];
 

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -8,8 +8,12 @@ if (! isset($_SERVER['SERVER_NAME'])) {
 $settings_file = __DIR__ . '/settings.inc.php';
 if (! file_exists($settings_file)) {
     die('File app/config/settings.inc.php is missing. Please check your configuration.');
+} else {
+    require $settings_file;
+    if (! isset($local_storage)) {
+        die('$local_storage is missing in your configuration file. Please update app/config/settings.inc.php');
+    }
 }
-require $settings_file;
 
 // Real data is in adi.inc.php, not under VCS
 if (is_file(__DIR__ . '/adi.inc.php')) {
@@ -18,6 +22,17 @@ if (is_file(__DIR__ . '/adi.inc.php')) {
     // Fake data to not break the app outside of production
     include __DIR__ . '/fake_adi.inc.php';
 }
+
+if (! isset($override_local)) {
+    // Make sure there is an array available to avoid further checks
+    $override_local = [];
+}
+
+$repo_local_path = function ($id, $folder) use ($local_storage, $override_local) {
+    return isset($override_local[$id]) ?
+        $override_local[$id] :
+        "{$local_storage}{$folder}/";
+};
 
 /*
  * List of supported repositories. Structure of the array
@@ -30,73 +45,73 @@ if (is_file(__DIR__ . '/adi.inc.php')) {
  */
 $repositories = [
     'www.mozilla.org' => [
-        'local_path'  => $repo1,
+        'local_path'  => $repo_local_path('www.mozilla.org', 'mozilla_org'),
         'public_path' => 'https://github.com/mozilla-l10n/www.mozilla.org/tree/master/',
         'repository'  => 'https://github.com/mozilla-l10n/www.mozilla.org',
         'vcs'         => 'git',
     ],
     'start.mozilla.org' => [
-        'local_path'  => $repo2,
+        'local_path'  => $repo_local_path('start.mozilla.org', 'fx36start'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/fx36start/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/fx36start/',
         'vcs'         => 'svn',
     ],
     'surveys' => [
-        'local_path'  => $repo3,
+        'local_path'  => $repo_local_path('surveys', 'surveys'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/surveys/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/surveys/',
         'vcs'         => 'svn',
     ],
     'marketing' => [
-        'local_path'  => $repo4,
+        'local_path'  => $repo_local_path('marketing', 'marketing'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/marketing/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/marketing/',
         'vcs'         => 'svn',
     ],
     'about:healthreport' => [
-        'local_path'  => $repo5,
+        'local_path'  => $repo_local_path('about:healthreport', 'fhr-l10n'),
         'public_path' => 'https://github.com/mozilla-l10n/fhr-l10n/tree/master/',
         'repository'  => 'https://github.com/mozilla-l10n/fhr-l10n',
         'vcs'         => 'git',
     ],
     'slogans' => [
-        'local_path'  => $repo6,
+        'local_path'  => $repo_local_path('slogans', 'slogans'),
         'public_path' => 'https://svn.mozilla.org/projects/granary/slogans/',
         'repository'  => 'https://svn.mozilla.org/projects/granary/slogans/',
         'vcs'         => 'svn',
     ],
     'engagement' => [
-        'local_path'  => $repo7,
+        'local_path'  => $repo_local_path('engagement', 'engagement-l10n'),
         'public_path' => 'https://github.com/mozilla-l10n/engagement-l10n/tree/master/',
         'repository'  => 'https://github.com/mozilla-l10n/engagement-l10n',
         'vcs'         => 'git',
     ],
     'add-ons' => [
-        'local_path'  => $repo8,
+        'local_path'  => $repo_local_path('add-ons', 'add-ons'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/add-ons/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/add-ons/',
         'vcs'         => 'svn',
     ],
     'firefox-updater' => [
-        'local_path'  => $repo9,
+        'local_path'  => $repo_local_path('firefox-updater', 'firefoxupdater'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/',
         'vcs'         => 'svn',
     ],
     'firefoxos-marketing' => [
-        'local_path'  => $repo10,
+        'local_path'  => $repo_local_path('firefoxos-marketing', 'firefoxos-marketing'),
         'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxos-marketing/',
         'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxos-marketing/',
         'vcs'         => 'svn',
     ],
     'contribute-autoreplies' => [
-        'local_path'  => $repo1,
+        'local_path'  => $repo_local_path('www.mozilla.org', 'mozilla_org'),
         'public_path' => 'https://github.com/mozilla-l10n/www.mozilla.org/tree/master/',
         'repository'  => 'https://github.com/mozilla-l10n/www.mozilla.org',
         'vcs'         => 'git',
     ],
     'appstores' => [
-        'local_path'  => $repo12,
+        'local_path'  => $repo_local_path('appstores', 'appstores'),
         'public_path' => 'https://github.com/mozilla-l10n/appstores/tree/master/',
         'repository'  => 'https://github.com/mozilla-l10n/appstores',
         'vcs'         => 'git',

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-$public_repo1  = 'https://github.com/mozilla-l10n/www.mozilla.org';
-$public_repo2  = 'https://svn.mozilla.org/projects/l10n-misc/trunk/fx36start/';
-$public_repo3  = 'https://svn.mozilla.org/projects/l10n-misc/trunk/surveys/';
-$public_repo4  = 'https://svn.mozilla.org/projects/l10n-misc/trunk/marketing/';
-$public_repo5  = 'https://github.com/mozilla-l10n/fhr-l10n/tree/master/';
-$public_repo6  = 'https://svn.mozilla.org/projects/granary/slogans/';
-$public_repo7  = 'https://github.com/mozilla-l10n/engagement-l10n/tree/master/';
-$public_repo8  = 'https://svn.mozilla.org/projects/l10n-misc/trunk/add-ons/';
-$public_repo9  = 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/';
-$public_repo10 = 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxos-marketing/';
-$public_repo11 = ''; // Free to use for new projects, was originally used for Tiles
-$public_repo12 = 'https://github.com/mozilla-l10n/appstores/tree/master/';
-
 // This is to avoid a warning in shell mode
 if (! isset($_SERVER['SERVER_NAME'])) {
     $_SERVER['SERVER_NAME'] = '';
@@ -33,11 +20,95 @@ if (is_file(__DIR__ . '/adi.inc.php')) {
 }
 
 /*
-If a file is not listed in $lang_flags, it's assumed to be non critical for all
-locales.
-If a flag is valid for all locales, set it to ['all']. If it's not, set the flag
-to the array of locales.
-*/
+ * List of supported repositories. Structure of the array
+ * ID (website name)
+ * |
+ * |__ local_path  = Path to the local repository (must end with slash)
+ * |__ public_path = Path used to create links to individual files
+ * |__ repository  = URL of the repository (for cloning)
+ * |__ vcs         = Type of VCS (git, svn)
+ */
+$repositories = [
+    'www.mozilla.org' => [
+        'local_path'  => $repo1,
+        'public_path' => 'https://github.com/mozilla-l10n/www.mozilla.org/tree/master/',
+        'repository'  => 'https://github.com/mozilla-l10n/www.mozilla.org',
+        'vcs'         => 'git',
+    ],
+    'start.mozilla.org' => [
+        'local_path'  => $repo2,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/fx36start/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/fx36start/',
+        'vcs'         => 'svn',
+    ],
+    'surveys' => [
+        'local_path'  => $repo3,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/surveys/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/surveys/',
+        'vcs'         => 'svn',
+    ],
+    'marketing' => [
+        'local_path'  => $repo4,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/marketing/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/marketing/',
+        'vcs'         => 'svn',
+    ],
+    'about:healthreport' => [
+        'local_path'  => $repo5,
+        'public_path' => 'https://github.com/mozilla-l10n/fhr-l10n/tree/master/',
+        'repository'  => 'https://github.com/mozilla-l10n/fhr-l10n',
+        'vcs'         => 'git',
+    ],
+    'slogans' => [
+        'local_path'  => $repo6,
+        'public_path' => 'https://svn.mozilla.org/projects/granary/slogans/',
+        'repository'  => 'https://svn.mozilla.org/projects/granary/slogans/',
+        'vcs'         => 'svn',
+    ],
+    'engagement' => [
+        'local_path'  => $repo7,
+        'public_path' => 'https://github.com/mozilla-l10n/engagement-l10n/tree/master/',
+        'repository'  => 'https://github.com/mozilla-l10n/engagement-l10n',
+        'vcs'         => 'git',
+    ],
+    'add-ons' => [
+        'local_path'  => $repo8,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/add-ons/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/add-ons/',
+        'vcs'         => 'svn',
+    ],
+    'firefox-updater' => [
+        'local_path'  => $repo9,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/',
+        'vcs'         => 'svn',
+    ],
+    'firefoxos-marketing' => [
+        'local_path'  => $repo10,
+        'public_path' => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxos-marketing/',
+        'repository'  => 'https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxos-marketing/',
+        'vcs'         => 'svn',
+    ],
+    'contribute-autoreplies' => [
+        'local_path'  => $repo1,
+        'public_path' => 'https://github.com/mozilla-l10n/www.mozilla.org/tree/master/',
+        'repository'  => 'https://github.com/mozilla-l10n/www.mozilla.org',
+        'vcs'         => 'git',
+    ],
+    'appstores' => [
+        'local_path'  => $repo12,
+        'public_path' => 'https://github.com/mozilla-l10n/appstores/tree/master/',
+        'repository'  => 'https://github.com/mozilla-l10n/appstores',
+        'vcs'         => 'git',
+    ],
+];
+
+/*
+ * If a file is not listed in $lang_flags, it's assumed to be non critical
+ * for all locales.
+ * If a flag is valid for all locales, set it to ['all']. If it's not,
+ * set the flag to the array of locales.
+ */
 $lang_flags = [];
 
 $mozillaorg_lang = [
@@ -644,144 +715,144 @@ $sites =
 [
     0 => [
         'www.mozilla.org',
-        $repo1,
+        $repositories['www.mozilla.org']['local_path'],
         '',
         $mozillaorg,
         $mozillaorg_lang,
         'en-US', // source locale
-        $public_repo1 . '/tree/master/',
+        $repositories['www.mozilla.org']['public_path'],
         $lang_flags['www.mozilla.org'],
         'lang',
     ],
 
     1 => [
         'start.mozilla.org',
-        $repo2,
+        $repositories['start.mozilla.org']['local_path'],
         'locale/',
         $startpage36,
         $startpage36_lang,
         'en-US', // source locale
-        $public_repo2,
+        $repositories['start.mozilla.org']['public_path'],
         $lang_flags['start.mozilla.org'],
         'lang',
     ],
 
     2 => [
         'surveys',
-        $repo3,
+        $repositories['surveys']['local_path'],
         '',
         $mozillaorg,
         $surveys_lang,
         'en-US', // source locale
-        $public_repo3,
+        $repositories['surveys']['public_path'],
         [],
         'lang',
     ],
 
     3 => [
         'marketing',
-        $repo4,
+        $repositories['marketing']['local_path'],
         '',
         $marketing,
         ['julyevent.lang'],
         'en-US', // source locale
-        $public_repo4,
+        $repositories['marketing']['public_path'],
         [],
         'lang',
     ],
 
     4 => [
         'about:healthreport',
-        $repo5,
+        $repositories['about:healthreport']['local_path'],
         '',
         $firefox_desktop_android,
         $firefoxhealthreport_lang,
         'en-US', // source locale
-        $public_repo5,
+        $repositories['about:healthreport']['public_path'],
         $lang_flags['about:healthreport'],
         'lang',
     ],
 
     5 => [
         'slogans',
-        $repo6,
+        $repositories['slogans']['local_path'],
         '',
         $slogans_locales,
         $slogans_lang,
         'en-US', // source locale
-        $public_repo6,
+        $repositories['slogans']['public_path'],
         $lang_flags['slogans'],
         'lang',
     ],
 
     6 => [
         'engagement',
-        $repo7,
+        $repositories['engagement']['local_path'],
         '',
         $engagement_locales,
         $engagement_lang,
         'en-US', // source locale
-        $public_repo7,
+        $repositories['engagement']['public_path'],
         $lang_flags['engagement'],
         'lang',
     ],
 
     7 => [
         'add-ons',
-        $repo8,
+        $repositories['add-ons']['local_path'],
         '',
         $addons_locales,
         $addons_lang,
         'en-US', // source locale
-        $public_repo8,
+        $repositories['add-ons']['public_path'],
         $lang_flags['add-ons'],
         'lang',
     ],
 
     8 => [
         'firefox-updater',
-        $repo9,
+        $repositories['firefox-updater']['local_path'],
         '',
         $firefox_updater_locales,
         $firefox_updater_lang,
         'en-US', // source locale
-        $public_repo9,
+        $repositories['firefox-updater']['public_path'],
         $lang_flags['firefox-updater'],
         'lang',
     ],
 
     9 => [
         'firefoxos-marketing',
-        $repo10,
+        $repositories['firefoxos-marketing']['local_path'],
         '',
         $fxos_marketing,
         $fxos_marketing_lang,
         'en-US', // source locale
-        $public_repo10,
+        $repositories['firefoxos-marketing']['public_path'],
         $lang_flags['firefoxos-marketing'],
         'lang',
     ],
 
     11 => [
         'contribute-autoreplies',
-        $repo1,
+        $repositories['contribute-autoreplies']['local_path'],
         '',
         $getinvolved_locales,
         $getinvolved_autoreplies,
         'en-US', // source locale
-        $public_repo1 . '/tree/master/',
+        $repositories['contribute-autoreplies']['public_path'],
         $lang_flags['contribute-autoreplies'],
         'raw',
     ],
 
     12 => [
         'appstores',
-        $repo12,
+        $repositories['appstores']['local_path'],
         '',
         $google_play_target,
         $appstores_lang,
         'en-US', // source locale
-        $public_repo12,
+        $repositories['appstores']['public_path'],
         $lang_flags['appstores'],
         'lang',
     ],

--- a/app/scripts/update_sources
+++ b/app/scripts/update_sources
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+namespace Langchecker;
+
+require_once __DIR__ . '/../inc/init.php';
+
+foreach ($repositories as $repository_id => $repository) {
+    $local_path = $repository['local_path'];
+    $vcs = $repository['vcs'];
+    if (! file_exists($local_path)) {
+        // Local repository doesn't exist, try to clone it
+        Utils::logger("Path for {$repository_id} does not exist ({$local_path}).");
+        switch ($vcs) {
+            case 'git':
+                Utils::logger("Creating Git repository: {$repository_id}.");
+                system(
+                    "git clone {$repository['repository']} {$local_path}",
+                    $return_code
+                );
+                break;
+
+            case 'svn':
+                Utils::logger("Creating SVN repository: {$repository_id}.");
+                system(
+                    "svn checkout {$repository['repository']} {$local_path}",
+                    $return_code
+                );
+                break;
+
+            default:
+                Utils::logger("Unknown VCS type ({$vcs}) for {$repository_id}.", 'quit');
+                $return_code = false;
+                break;
+        }
+        if ($return_code) {
+            Utils::logger("There was an error creating the repository for {$repository_id}.");
+        }
+    } else {
+        switch ($vcs) {
+            case 'git':
+                Utils::logger("Updating Git repository: {$repository_id}.");
+                system(
+                    "git --work-tree={$local_path} --git-dir={$local_path}.git pull origin master",
+                    $return_code
+                );
+                break;
+
+            case 'svn':
+                Utils::logger("Updating SVN repository: {$repository_id}.");
+                system(
+                    "svn update {$local_path}",
+                    $return_code
+                );
+                break;
+
+            default:
+                Utils::logger("Unknown VCS type ({$vcs}) for {$repository_id}.", 'quit');
+                $return_code = false;
+                break;
+        }
+        if ($return_code) {
+            Utils::logger("There was an error updating repository for {$repository_id}.");
+        }
+    }
+}


### PR DESCRIPTION
One last update: make the repos storage structure a bit less cryptic, create a script that can be used to update all repos from a single cronjob.

I'm tempted to take it one step further, and store in settings.php only one or two paths (like GIT_PATH and SVN_PATH) like we do in Transvision, and eventually add a ´local_folder´ to the array to specify a different checkout folder.

Thoughts?

Based on #401.