### PR TITLE
Fix supported locales for landing pages (Android, iOS)

### DIFF
--- a/app/config/locales.inc.php
+++ b/app/config/locales.inc.php
@@ -53,6 +53,54 @@ $firefox_locales = array_diff(
 $firefox_desktop_android = array_merge($firefox_locales, $fennec_locales);
 
 /*
+    source: https://l10n.mozilla-community.org/~flod/webstatus/api/?product=firefox-ios
+    translations are at: https://github.com/mozilla-l10n/firefoxios-l10n/
+    For iOS we used the locale code es for Spanish from Spain, that was a
+    mistake, this is why I changed it to es-ES in the array below, otherwise
+    the Spanish team would have to work in the es-ES folder for Android and
+    the es folder for iOS
+    Make sure to update the store_l10n project when you update this list:
+    https://github.com/mozilla-l10n/stores_l10n/blob/15633f598a78357575630fdc235f9cbccc4c6ed3/app/classes/Stores/Project.php#L43
+*/
+$apple_store_target = [
+    'ar', 'az', 'bg', 'bn-IN', 'br', 'cs', 'cy', 'da', 'de', 'dsb', 'el',
+    'eo', 'es-ES', 'es-CL', 'es-MX', 'fa', 'fr', 'fy-NL', 'ga-IE',
+    'gd', 'gl', 'hsb', 'id', 'is', 'it', 'ja', 'kk', 'km', 'ko', 'lo', 'lt',
+    'lv', 'ml', 'ms', 'my', 'nb-NO', 'nl', 'nn-NO', 'or', 'pl', 'pt-BR',
+    'pt-PT', 'rm', 'ro', 'ru', 'sk', 'sl', 'son', 'sv-SE', 'th', 'tl', 'tr',
+    'uk', 'uz', 'zh-CN', 'zh-TW',
+];
+
+/*
+    Source : http://hg.mozilla.org/releases/mozilla-release/raw-file/tip/mobile/android/locales/maemo-locales
+    Source : http://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/mobile/android/locales/maemo-locales
+    Source : http://hg.mozilla.org/releases/mozilla-aurora/raw-file/tip/mobile/android/locales/maemo-locales
+    When updating, make sure to update store_l10n project as well:
+    https://github.com/mozilla-l10n/stores_l10n/blob/15633f598a78357575630fdc235f9cbccc4c6ed3/app/classes/Stores/Project.php#L16
+*/
+$android_locales = [
+    'an', 'as', 'az', 'be', 'bn-IN', 'br', 'ca', 'cs', 'cy', 'da', 'de',
+    'dsb', 'en-GB', 'en-ZA', 'eo', 'es-AR', 'es-ES', 'es-MX', 'et', 'eu',
+    'fi', 'ff', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'hi-IN', 'hr',
+    'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'kk', 'kn', 'ko', 'lt',
+    'lv', 'mai', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl', 'or', 'pa-IN', 'pl',
+    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'son', 'sq', 'sv-SE', 'ta',
+    'te', 'th', 'tr', 'uk', 'uz', 'zh-CN', 'zh-TW',
+];
+
+// List provided by Release-drivers, needs access to a Google Play publishing account
+$google_play_locales = [
+    'af', 'ar', 'be', 'bg', 'cs', 'ca', 'da', 'de', 'el', 'en-GB',
+    'es-MX', 'es-ES', 'et', 'fa', 'fi', 'fr', 'hi-IN', 'hu', 'hr',
+    'id', 'it', 'he', 'ja', 'ko', 'lt', 'lv', 'ms', 'nl', 'nb-NO',
+    'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sk', 'sl', 'sr',
+    'sv-SE', 'sw', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW', 'zu',
+];
+
+// Locales that we do support and that Google Play supports too
+$google_play_target = array_intersect($android_locales, $google_play_locales);
+
+/*
     Thunderbird locales on Release channel
     Source: http://hg.mozilla.org/releases/comm-release/raw-file/tip/mail/locales/shipped-locales
 */

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -195,7 +195,7 @@ $lang_flags['www.mozilla.org'] = [
     'download.lang'                           => [ 'critical' => ['all'] ],
     'download_button.lang'                    => [ 'critical' => ['all'] ],
     'firefox/android/index.lang'              => [
-        'critical' => ['all'],
+        'critical' => [$android_locales],
         'opt-in'   => ['all'],
     ],
     'firefox/australis/firefox_tour.lang'     => [ 'critical' => ['all'] ],
@@ -216,7 +216,10 @@ $lang_flags['www.mozilla.org'] = [
     'firefox/hello.lang'                      => [ 'obsolete' => ['all'] ],
     'firefox/hello-2016.lang'                 => [ 'critical' => ['all'] ],
     'firefox/installer-help.lang'             => [ 'critical' => ['all'] ],
-    'firefox/ios.lang'                        => [ 'critical' => ['all'] ],
+    'firefox/ios.lang'                        => [
+        'critical' => [$apple_store_target],
+        'opt-in'   => ['all'],
+    ],
     'firefox/new.lang'                        => [ 'critical' => ['all'] ],
     'firefox/os/faq.lang'                     => [ 'obsolete' => ['all'] ],
     'firefox/os/index-new.lang'               => [ 'obsolete' => ['all'] ],
@@ -552,23 +555,6 @@ $addons_locales = [
     'pt-BR', 'ru', 'sq', 'zh-TW',
 ];
 
-/*
-    Source : http://hg.mozilla.org/releases/mozilla-release/raw-file/tip/mobile/android/locales/maemo-locales
-    Source : http://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/mobile/android/locales/maemo-locales
-    Source : http://hg.mozilla.org/releases/mozilla-aurora/raw-file/tip/mobile/android/locales/maemo-locales
-    When updating, make sure to update store_l10n project as well:
-    https://github.com/mozilla-l10n/stores_l10n/blob/15633f598a78357575630fdc235f9cbccc4c6ed3/app/classes/Stores/Project.php#L16
-*/
-$android_locales = [
-    'an', 'as', 'az', 'be', 'bn-IN', 'br', 'ca', 'cs', 'cy', 'da', 'de',
-    'dsb', 'en-GB', 'en-ZA', 'eo', 'es-AR', 'es-ES', 'es-MX', 'et', 'eu',
-    'fi', 'ff', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'hi-IN', 'hr',
-    'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'kk', 'kn', 'ko', 'lt',
-    'lv', 'mai', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl', 'or', 'pa-IN', 'pl',
-    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'son', 'sq', 'sv-SE', 'ta',
-    'te', 'th', 'tr', 'uk', 'uz', 'zh-CN', 'zh-TW',
-];
-
 $firefox_os = [
     'af', 'ar', 'bg', 'bm', 'bn-BD', 'bn-IN', 'ca' , 'cs',
     'de', 'ee', 'el', 'es-AR', 'es-CL', 'es-ES', 'es-MX',
@@ -619,36 +605,22 @@ $getinvolved_locales = [
     'sq', 'sr', 'sv-SE', 'ta', 'tr', 'uk', 'zh-CN', 'zh-TW',
 ];
 
-// List provided by Release-drivers, needs access to a Google Play publishing account
-$google_play_locales = [
-    'af', 'ar', 'be', 'bg', 'cs', 'ca', 'da', 'de', 'el', 'en-GB',
-    'es-MX', 'es-ES', 'et', 'fa', 'fi', 'fr', 'hi-IN', 'hu', 'hr',
-    'id', 'it', 'he', 'ja', 'ko', 'lt', 'lv', 'ms', 'nl', 'nb-NO',
-    'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sk', 'sl', 'sr',
-    'sv-SE', 'sw', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW', 'zu',
-];
+// List of locales supported for the landing page (larger than the App Store)
+$ios_landing_page = array_unique(array_merge(
+    $apple_store_target,
+    [
+        'af', 'an', 'bn-BD', 'ca', 'en-GB', 'es-AR', 'eu',
+        'gn', 'hi-IN', 'hu', 'ka', 'kn', 'lij', 'sq', 'sr',
+    ]
+));
 
-// Locales that we do support and that Google Play supports too
-$google_play_target = array_intersect($android_locales, $google_play_locales);
-
-/*
-    source: https://l10n.mozilla-community.org/~flod/webstatus/api/?product=firefox-ios
-    translations are at: https://github.com/mozilla-l10n/firefoxios-l10n/
-    For iOS we used the locale code es for Spanish from Spain, that was a
-    mistake, this is why I changed it to es-ES in the array below, otherwise
-    the Spanish team would have to work in the es-ES folder for Android and
-    the es folder for iOS
-    Make sure to update the store_l10n project when you update this list:
-    https://github.com/mozilla-l10n/stores_l10n/blob/15633f598a78357575630fdc235f9cbccc4c6ed3/app/classes/Stores/Project.php#L43
-*/
-$apple_store_target = [
-    'ar', 'az', 'bg', 'bn-IN', 'br', 'cs', 'cy', 'da', 'de', 'dsb', 'el',
-    'eo', 'es-ES', 'es-CL', 'es-MX', 'fa', 'fr', 'fy-NL', 'ga-IE',
-    'gd', 'gl', 'hsb', 'id', 'is', 'it', 'ja', 'kk', 'km', 'ko', 'lo', 'lt',
-    'lv', 'ml', 'ms', 'my', 'nb-NO', 'nl', 'nn-NO', 'or', 'pl', 'pt-BR',
-    'pt-PT', 'rm', 'ro', 'ru', 'sk', 'sl', 'son', 'sv-SE', 'th', 'tl', 'tr',
-    'uk', 'uz', 'zh-CN', 'zh-TW',
-];
+// List of locales supported for the landing page
+$android_landing_page = array_unique(array_merge(
+    $android_locales,
+    [
+        'af', 'bn-BD', 'cak', 'fa', 'sat', 'tsz',
+    ]
+));
 
 $mwc_locales = [
     'ca', 'cs', 'de', 'el', 'es-ES', 'es-MX', 'fr', 'hu', 'it',
@@ -785,7 +757,7 @@ $sites =
         'appstores',
         $repositories['appstores']['local_path'],
         '',
-        $google_play_target,
+        array_unique(array_merge($google_play_target, $apple_store_target)),
         $appstores_lang,
         'en-US', // source locale
         $repositories['appstores']['public_path'],
@@ -800,7 +772,7 @@ $langfiles_subsets = [
         'download.lang'                         => $mozillaorg,
         'download_button.lang'                  => $mozillaorg,
         'esr.lang'                              => ['de', 'fr'],
-        'firefox/android/index.lang'            => $android_locales,
+        'firefox/android/index.lang'            => $android_landing_page,
         'firefox/australis/firefox_tour.lang'   => $firefox_locales,
         'firefox/australis/fx36_tour.lang'      => $firefox_locales,
         'firefox/channel.lang'                  => $mozillaorg, // Has Firefox for Android download buttons
@@ -844,7 +816,7 @@ $langfiles_subsets = [
         'firefox/hello.lang'                      => $firefox_locales,
         'firefox/hello-2016.lang'                 => $firefox_locales,
         'firefox/installer-help.lang'             => $firefox_locales,
-        'firefox/ios.lang'                        => $apple_store_target,
+        'firefox/ios.lang'                        => $ios_landing_page,
         'firefox/new.lang'                        => $firefox_desktop_android,
         'firefox/nightly_firstrun.lang'           =>
             [


### PR DESCRIPTION
While I absolutely understand the need to have arrays easy to map to shipping versions, the lhe last updates left quite some issues. This is the list of file untracked only currently in mozilla.org
```
af/firefox/android/index.lang
bn-BD/firefox/android/index.lang
cak/firefox/android/index.lang
fa/firefox/android/index.lang
sat/firefox/android/index.lang
tsz/firefox/android/index.lang
ach/firefox/ios.lang
af/firefox/ios.lang
an/firefox/ios.lang
as/firefox/ios.lang
ast/firefox/ios.lang
be/firefox/ios.lang
bn-BD/firefox/ios.lang
brx/firefox/ios.lang
bs/firefox/ios.lang
ca/firefox/ios.lang
en-GB/firefox/ios.lang
es-AR/firefox/ios.lang
et/firefox/ios.lang
eu/firefox/ios.lang
ff/firefox/ios.lang
fi/firefox/ios.lang
gn/firefox/ios.lang
gu-IN/firefox/ios.lang
he/firefox/ios.lang
hi-IN/firefox/ios.lang
hr/firefox/ios.lang
hu/firefox/ios.lang
hy-AM/firefox/ios.lang
ka/firefox/ios.lang
kn/firefox/ios.lang
kok/firefox/ios.lang
ks/firefox/ios.lang
lij/firefox/ios.lang
ltg/firefox/ios.lang
mai/firefox/ios.lang
mk/firefox/ios.lang
mr/firefox/ios.lang
ne-NP/firefox/ios.lang
oc/firefox/ios.lang
pa-IN/firefox/ios.lang
sat/firefox/ios.lang
si/firefox/ios.lang
sq/firefox/ios.lang
sr/firefox/ios.lang
ta/firefox/ios.lang
te/firefox/ios.lang
ur/firefox/ios.lang
vi/firefox/ios.lang
xh/firefox/ios.lang
zu/firefox/ios.lang
```

I don't believe we should prevent  people from localizing a landing page even if the product itself is not localized (yet): we have [af](https://bugzilla.mozilla.org/show_bug.cgi?id=1161450) that requested the Android landing page explicitly, and [tsz](https://bugzilla.mozilla.org/show_bug.cgi?id=1178947) which is a locale currently localizing Fennec. More important we shouldn't lose work already done (that's more for iOS).

This is the list of files that should be removed after this merges
```
ach/firefox/ios.lang
as/firefox/ios.lang
ast/firefox/ios.lang
be/firefox/ios.lang
brx/firefox/ios.lang
bs/firefox/ios.lang
et/firefox/ios.lang
ff/firefox/ios.lang
fi/firefox/ios.lang
gu-IN/firefox/ios.lang
he/firefox/ios.lang
hr/firefox/ios.lang
hy-AM/firefox/ios.lang
kok/firefox/ios.lang
ks/firefox/ios.lang
ltg/firefox/ios.lang
mai/firefox/ios.lang
mk/firefox/ios.lang
mr/firefox/ios.lang
ne-NP/firefox/ios.lang
oc/firefox/ios.lang
pa-IN/firefox/ios.lang
sat/firefox/ios.lang
si/firefox/ios.lang
ta/firefox/ios.lang
te/firefox/ios.lang
ur/firefox/ios.lang
vi/firefox/ios.lang
xh/firefox/ios.lang
zu/firefox/ios.lang
```

There are still quire a few untracked files in 12, but I would leave them to you to analyze since I'm not familiar with the AppStore project.

To make things work I had to move a few arrays to locales.php, but I don't think that's an issue. It also makes updates easier, since the file is a lot smaller.
This also fixes the list of supported locales for the website 12.