### PR TITLE
Remove Firefox OS marketing files from locale dashboards

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -398,7 +398,17 @@ $fxos_marketing_lang = [
     'slogans/firefoxos.lang',
     'slogans/marketplacebadge.lang',
 ];
-$lang_flags['firefoxos-marketing'] = [];
+
+$lang_flags['firefoxos-marketing'] = [
+    'marketplace/marketplace_l10n_feed.lang' => [ 'obsolete' => ['all'] ],
+    'screenshots/screenshots_2_0.lang'       => [ 'obsolete' => ['all'] ],
+    'screenshots/screenshots_2_0_b.lang'     => [ 'obsolete' => ['all'] ],
+    'screenshots/screenshots_dolphin.lang'   => [ 'obsolete' => ['all'] ],
+    'screenshots/screenshots.lang'           => [ 'obsolete' => ['all'] ],
+    'screenshots/screenshots_tarako.lang'    => [ 'obsolete' => ['all'] ],
+    'slogans/firefoxos.lang'                 => [ 'obsolete' => ['all'] ],
+    'slogans/marketplacebadge.lang'          => [ 'obsolete' => ['all'] ],
+];
 
 $appstores_lang = [
     'description_beta_page.lang',
@@ -605,7 +615,7 @@ $marketplacebadge_locales = [
 $slogans_locales = [
     'af', 'ar', 'bg', 'bm', 'bn-IN', 'ca', 'cs', 'de', 'ee', 'el',
     'es-ES', 'ff', 'fr', 'ha', 'hi-IN', 'hr', 'hu', 'ig', 'it',
-    'ja', 'ko', 'ln', 'mg', 'mk', 'my', 'pl', 'pt-BR', 'ro', 'son', 'sr',
+    'ja', 'ko', 'ln', 'mg', 'mk', 'my', 'pl', 'pt-BR', 'ro', 'son', 'sq', 'sr',
     'sr-Latn', 'sv-SE', 'sw', 'ta', 'tl', 'tn', 'wo', 'xh',
     'yo', 'zh-CN', 'zh-TW', 'zu',
 ];


### PR DESCRIPTION
I noticed some files like screenshots_2_0.lang were still displayed on locale dashboards (for Arabic, for instance). This will help localizers set priorities and prevent them from translating stuff that won’t be used.
@flodolo does that look good to you?

I imagine we’ll remove the files at some point, but this is a first step