### PR TITLE
Remove $disable_magic setting, properly catch exception in finfo()

### DIFF
--- a/app/config/settings.inc.php.ini
+++ b/app/config/settings.inc.php.ini
@@ -34,12 +34,3 @@ const GITHUB_SECRET = '';
         'www.mozilla.org' => '/full/path/to/your/clone',
     ];
 */
-
-/*
-    Langchecker uses finfo() to determine the encoding of a file. In some
-    configurations, e.g. PHP installed via homebrew on Mac, the local libmagic
-    database doesn't match the version of PHP, and there's no way for code to
-    check the database integrity. Default value for this pref, even if not
-    declared, is false.
-*/
-$disable_libmagic = false;

--- a/app/controllers/errors.php
+++ b/app/controllers/errors.php
@@ -55,7 +55,7 @@ foreach ($mozilla as $current_locale) {
                 }
 
                 // Check if the lang file is not in UTF-8 or US-ASCII
-                if (Utils::isUTF8($locale_filename, $disable_libmagic) == false) {
+                if (Utils::isUTF8($locale_filename) == false) {
                     $errors[$current_locale][$current_website_name][$current_filename][] = [
                         'message' => "File is not saved with UTF-8 encoding.",
                         'type'    => 'generic',

--- a/app/controllers/export.php
+++ b/app/controllers/export.php
@@ -39,7 +39,7 @@ foreach ($sites as $website) {
 
                 $errors_number = LangManager::countErrors($locale_analysis['errors']);
                 // Also include encoding problems as an error
-                if (Utils::isUTF8($locale_filename, $disable_libmagic) == false) {
+                if (Utils::isUTF8($locale_filename) == false) {
                     $errors_number++;
                 }
                 $export_data[$website_name][$displayed_filename]['errors'] = $errors_number;

--- a/app/controllers/listsitesforlocale.php
+++ b/app/controllers/listsitesforlocale.php
@@ -60,7 +60,7 @@ foreach (Project::getWebsitesByDataType($sites, 'lang') as $current_website) {
 
         $errors = [];
         // Check if the lang file is in UTF-8
-        if (Utils::isUTF8($locale_filename, $disable_libmagic) == false) {
+        if (Utils::isUTF8($locale_filename) == false) {
             $status .= ' file_notutf8';
             $count_errors += 1;
             $errors[] = [

--- a/app/inc/init.php
+++ b/app/inc/init.php
@@ -28,11 +28,6 @@ if (! file_exists($settings_file)) {
     }
 }
 
-// Check $disable_libmagic
-if (! isset($disable_libmagic)) {
-    $disable_libmagic = false;
-}
-
 // URL used to include web assets
 if (! isset($webroot_folder)) {
     die('$webroot_folder setting is missing from app/config/settings.inc.php. Please update your settings file.');

--- a/tests/units/Langchecker/Utils.php
+++ b/tests/units/Langchecker/Utils.php
@@ -185,21 +185,20 @@ class Utils extends atoum\test
         $base_folder = TEST_FILES . 'dotlang/';
 
         return [
-            [$base_folder . 'toto.lang', false, true],
-            [$base_folder . 'toto.lang', true, true],
-            [$base_folder . 'notutf8.lang', false, false],
+            [$base_folder . 'toto.lang', true],
+            [$base_folder . 'notutf8.lang', false],
         ];
     }
 
     /**
      * @dataProvider isUTF8DP
      */
-    public function testIsUTF8($a, $b, $c)
+    public function testIsUTF8($a, $b)
     {
         $obj = new _Utils();
         $this
-            ->boolean($obj->isUTF8($a, $b))
-                ->isEqualTo($c);
+            ->boolean($obj->isUTF8($a))
+                ->isEqualTo($b);
     }
 
     public function checkEOLDP()


### PR DESCRIPTION
Undo the last patch and catch exception on finfo(), store information about lib magic in a private static variable.