### PR TITLE
bootstrap locales ncj, zam; add sv-SE to thunderbird/channel.lang

### DIFF
--- a/app/config/locales.inc.php
+++ b/app/config/locales.inc.php
@@ -32,7 +32,7 @@ $fennec_locales = [
 
 // List of locales only working on mozilla.org
 $mozorg_locales = [
-    'am', 'nv',
+    'am', 'ncj', 'nv', 'zam',
 ];
 
 /*
@@ -73,8 +73,8 @@ $newsletter_locales = [
 $locamotion_locales = [
     'ach', 'af', 'bm', 'bn-BD', 'br', 'ca', 'cak', 'cy', 'ee', 'en-ZA', 'ff',
     'ga-IE', 'gn', 'ha', 'hi-IN', 'hto', 'ig', 'kk', 'ln', 'lt', 'lv', 'mai',
-    'mg', 'nb-NO', 'ne-NP', 'nv', 'oc', 'or', 'pbb', 'qvi', 'son', 'sw', 'ta',
-    'tn', 'trs', 'ur', 'wo', 'xh', 'yo', 'zu',
+    'mg', 'nb-NO', 'ncj', 'ne-NP', 'nv', 'oc', 'or', 'pbb', 'qvi', 'son', 'sw', 'ta',
+    'tn', 'trs', 'ur', 'wo', 'xh', 'yo', 'zam', 'zu',
 ];
 
 /*

--- a/app/config/locales.inc.php
+++ b/app/config/locales.inc.php
@@ -12,10 +12,10 @@ $mozilla = [
     'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN',
     'he', 'hi-IN', 'hr', 'hsb', 'hto', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja',
     'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lo', 'lt', 'ltg', 'lv', 'mai',
-    'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'nv', 'oc',
+    'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ncj', 'ne-NP', 'nl', 'nn-NO', 'nv', 'oc',
     'or', 'pa-IN', 'pbb', 'pl', 'pt-BR', 'pt-PT', 'qvi', 'rm', 'ro', 'ru', 'si',
     'sk', 'sl', 'son', 'sq', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'trs',
-    'uk', 'ur', 'uz', 'vi', 'xh', 'zh-CN', 'zh-HK', 'zh-TW', 'zu',
+    'uk', 'ur', 'uz', 'vi', 'xh', 'zam', 'zh-CN', 'zh-HK', 'zh-TW', 'zu',
 ];
 sort($mozilla);
 

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -829,7 +829,7 @@ $langfiles_subsets = [
         'thunderbird/channel.lang' =>
             [
                 'cy', 'cs', 'de', 'en-GB', 'es-ES', 'fi', 'fr', 'it', 'ja', 'kab', 'ko',
-                'lt', 'nl', 'pl', 'pt-BR', 'ru', 'sq', 'uk', 'zh-TW',
+                'lt', 'nl', 'pl', 'pt-BR', 'ru', 'sv-SE', 'sq', 'uk', 'zh-TW',
             ],
         'thunderbird/features.lang'      => $thunderbird_locales,
         'thunderbird/index.lang'         => $thunderbird_locales,

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -529,8 +529,8 @@ $getinvolved_locales = [
     'af', 'am', 'ar', 'az', 'bg', 'bn-BD', 'cs', 'cy', 'de', 'dsb', 'el',
     'en-GB', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'fa', 'fr',
     'fy-NL', 'he', 'hi-IN', 'hr', 'hsb', 'id', 'it', 'kab', 'ko',
-    'lt', 'ms', 'nl', 'nv', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sl',
-    'son', 'sq', 'sr', 'sv-SE', 'ta', 'tr', 'uk', 'zh-CN', 'zh-TW',
+    'lt', 'ms', 'ncj', 'nl', 'nv', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sl',
+    'son', 'sq', 'sr', 'sv-SE', 'ta', 'tr', 'uk', 'zam', 'zh-CN', 'zh-TW',
 ];
 
 // List of locales supported for the landing page (larger than the App Store)
@@ -651,9 +651,9 @@ $langfiles_subsets = [
                 'af', 'am', 'ca', 'cs', 'cy', 'de', 'dsb', 'el', 'en-GB', 'es-AR',
                 'es-CL', 'es-ES', 'es-MX', 'eu', 'fa', 'ff', 'fr', 'fy-NL',
                 'ga-IE', 'gd', 'gl', 'he', 'hi-IN', 'hsb', 'hu', 'id',
-                'it', 'ja', 'kab', 'km', 'ko', 'lt', 'ms', 'nl', 'nv', 'pl', 'pt-BR',
+                'it', 'ja', 'kab', 'km', 'ko', 'lt', 'ms', 'ncj', 'nl', 'nv', 'pl', 'pt-BR',
                 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'son', 'sq', 'sr',
-                'sv-SE', 'uk', 'uz', 'xh', 'zh-CN', 'zh-TW',
+                'sv-SE', 'uk', 'uz', 'xh', 'zam', 'zh-CN', 'zh-TW',
             ],
         'firefox/desktop/trust.lang' => $firefox_locales,
         'firefox/developer.lang'     => $firefox_locales,
@@ -741,9 +741,9 @@ $langfiles_subsets = [
             [
                 'am', 'ca', 'cs', 'cy', 'de', 'dsb', 'el', 'en-GB', 'es-AR',
                 'es-CL', 'es-ES', 'es-MX', 'eu', 'fa', 'fr', 'fy-NL',
-                'hi-IN', 'hsb', 'it', 'kab', 'ko', 'ja', 'km', 'lt', 'ms', 'nl',
+                'hi-IN', 'hsb', 'it', 'kab', 'ko', 'ja', 'km', 'lt', 'ms', 'ncj', 'nl',
                 'nv', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'son', 'sq', 'sr',
-                'sv-SE', 'tr', 'uk', 'zh-CN', 'zh-TW',
+                'sv-SE', 'tr', 'uk', 'zam', 'zh-CN', 'zh-TW',
             ],
         'main.lang'                         => $mozillaorg,
         'mozorg/404.lang'                   => $mozillaorg,
@@ -754,8 +754,8 @@ $langfiles_subsets = [
             [
                 'af', 'am', 'bn-BD', 'ca', 'cs', 'cy', 'de', 'dsb', 'en-GB', 'es-CL',
                 'es-MX', 'eu', 'fa', 'fr', 'gl', 'hsb', 'it', 'ja', 'kab',
-                'km', 'ko', 'lt', 'nl', 'nv', 'pa-IN', 'pt-BR', 'pt-PT', 'ro',
-                'ru', 'sk', 'son', 'sq', 'sv-SE', 'uk', 'uz',
+                'km', 'ko', 'lt', 'ncj', 'nl', 'nv', 'pa-IN', 'pt-BR', 'pt-PT', 'ro',
+                'ru', 'sk', 'son', 'sq', 'sv-SE', 'uk', 'uz', 'zam',
                 'zh-CN', 'zh-TW',
             ],
         'mozorg/about/history.lang' =>
@@ -763,10 +763,10 @@ $langfiles_subsets = [
                 'af', 'am', 'ar', 'bg', 'bn-BD', 'ca', 'cs', 'cy', 'de', 'dsb',
                 'el', 'en-GB', 'es-AR', 'es-CL', 'es-ES', 'es-MX',
                 'eu', 'fa', 'fr', 'fy-NL', 'gl', 'hr', 'hsb', 'id',
-                'it', 'ja', 'kab', 'km', 'ko', 'lt', 'ms', 'nl', 'pa-IN',
+                'it', 'ja', 'kab', 'km', 'ko', 'lt', 'ms', 'ncj', 'nl', 'pa-IN',
                 'nv', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk',
                 'sl', 'son', 'sq', 'sr', 'sv-SE', 'ta', 'tr', 'uk',
-                'uz', 'zh-CN', 'zh-TW',
+                'uz', 'zam', 'zh-CN', 'zh-TW',
             ],
         'mozorg/about/manifesto.lang' =>
             [
@@ -774,9 +774,9 @@ $langfiles_subsets = [
                 'dsb', 'el', 'en-GB', 'es-AR', 'es-CL', 'es-ES', 'es-MX',
                 'eu', 'fa', 'fi', 'fr', 'fy-NL', 'gd', 'gl',
                 'hi-IN', 'hr', 'hsb', 'hu', 'id', 'it', 'ja', 'kab',
-                'km', 'ko', 'lt', 'mk', 'ms', 'nl', 'nv', 'pl', 'pt-BR',
+                'km', 'ko', 'lt', 'mk', 'ms', 'ncj', 'nl', 'nv', 'pl', 'pt-BR',
                 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'son', 'sq', 'sr', 'sv-SE',
-                'tr', 'uk', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW',
+                'tr', 'uk', 'uz', 'vi', 'xh', 'zam', 'zh-CN', 'zh-TW',
             ],
         'mozorg/contribute/index.lang'      => $getinvolved_locales,
         'mozorg/contribute/signup.lang'     => $getinvolved_locales,
@@ -829,7 +829,7 @@ $langfiles_subsets = [
         'thunderbird/channel.lang' =>
             [
                 'cy', 'cs', 'de', 'en-GB', 'es-ES', 'fi', 'fr', 'it', 'ja', 'kab', 'ko',
-                'lt', 'nl', 'pl', 'pt-BR', 'ru', 'sv-SE', 'sq', 'uk', 'zh-TW',
+                'lt', 'nl', 'pl', 'pt-BR', 'ru', 'sq', 'sv-SE', 'uk', 'zh-TW',
             ],
         'thunderbird/features.lang'      => $thunderbird_locales,
         'thunderbird/index.lang'         => $thunderbird_locales,


### PR DESCRIPTION
Add new locales to mozilla.org pages:
- bug 1343325 (ncj)
- bug 1342627 (zam)
Add sv-SE to an opt-in page: bug 1342816