### PR TITLE
Track Appstores files for 52 and 53 beta 

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -420,6 +420,8 @@ $appstores_lang = [
     'fx_android/whatsnew/android_51_beta.lang',
     'fx_android/whatsnew/android_51.lang',
     'fx_android/whatsnew/android_52_beta.lang',
+    'fx_android/whatsnew/android_52.lang',
+    'fx_android/whatsnew/android_53_beta.lang',
     'fx_ios/description_release.lang',
     'fx_ios/screenshots_v3.lang',
     'fx_ios/whatsnew/ios_2_1.lang',
@@ -446,13 +448,14 @@ $lang_flags['appstores'] = [
     'fx_android/whatsnew/android_45.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_46.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_47.lang'      => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_48.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_46_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_47_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_48_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_49_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_50_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_51_beta.lang' => [ 'obsolete' => ['all'] ],
+    'fx_android/whatsnew/android_52_beta.lang' => [ 'obsolete' => ['all'] ],
+    'fx_android/whatsnew/android_53_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_ios/description_release.lang'          => [
         'critical' => [
             'de', 'es-ES', 'es-MX', 'fr', 'id', 'it',
@@ -481,7 +484,7 @@ $no_active_tag = [
 
 $deadline = [
     'fx_android/description_release.lang'          => '2016-04-30', // appstores project
-    'fx_android/whatsnew/android_50.lang'          => '2016-11-14', // appstores project
+    'fx_android/whatsnew/android_52.lang'          => '2017-03-07', // appstores project
     'fx_ios/description_release.lang'              => '2016-03-30', // appstores project
     'fx_ios/whatsnew/ios_6_0.lang'                 => '2017-01-06', // appstores project
     'download_button.lang'                         => '2016-04-29',
@@ -1002,6 +1005,7 @@ $langfiles_subsets = [
         'fx_android/whatsnew/android_49.lang'      => array_merge($fx_android_store, ['ar']),
         'fx_android/whatsnew/android_50.lang'      => array_merge($fx_android_store, ['ar']),
         'fx_android/whatsnew/android_51.lang'      => array_merge($fx_android_store, ['ar']),
+        'fx_android/whatsnew/android_52.lang'      => array_merge($fx_android_store, ['ar']),
         'fx_android/whatsnew/android_46_beta.lang' => $fx_android_store,
         'fx_android/whatsnew/android_47_beta.lang' => $fx_android_store,
         'fx_android/whatsnew/android_48_beta.lang' => $fx_android_store,
@@ -1009,6 +1013,7 @@ $langfiles_subsets = [
         'fx_android/whatsnew/android_50_beta.lang' => $fx_android_store,
         'fx_android/whatsnew/android_51_beta.lang' => $fx_android_store,
         'fx_android/whatsnew/android_52_beta.lang' => $fx_android_store,
+        'fx_android/whatsnew/android_53_beta.lang' => $fx_android_store,
         'fx_ios/description_release.lang'          => $fx_ios_store,
         'fx_ios/screenshots_v3.lang'               => [
             'de', 'es-ES', 'es-MX', 'fr', 'id', 'it', 'ja', 'pt-BR', 'ru', 'zh-CN', 'zh-TW',

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -448,6 +448,9 @@ $lang_flags['appstores'] = [
     'fx_android/whatsnew/android_45.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_46.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_47.lang'      => [ 'obsolete' => ['all'] ],
+    'fx_android/whatsnew/android_48.lang'      => [ 'obsolete' => ['all'] ],
+    'fx_android/whatsnew/android_49.lang'      => [ 'obsolete' => ['all'] ],
+    'fx_android/whatsnew/android_50.lang'      => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_46_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_47_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_48_beta.lang' => [ 'obsolete' => ['all'] ],
@@ -455,7 +458,6 @@ $lang_flags['appstores'] = [
     'fx_android/whatsnew/android_50_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_51_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_android/whatsnew/android_52_beta.lang' => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_53_beta.lang' => [ 'obsolete' => ['all'] ],
     'fx_ios/description_release.lang'          => [
         'critical' => [
             'de', 'es-ES', 'es-MX', 'fr', 'id', 'it',


### PR DESCRIPTION
Not sure why the deadline for What's New skips from Firefox 51 to 52 in this file... doesn't make much sense to me. Updated with latest version and dates nevertheless.