### PR TITLE
Remove Maker Party survey for Polish

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -678,7 +678,7 @@ $engagement_lang = [
     ],
     'surveys/survey_maker_party_2016.lang' => [
         'supported_locales' => [
-            'bg', 'cs', 'de', 'es', 'fr', 'it', 'nl', 'pl', 'sl',
+            'bg', 'cs', 'de', 'es', 'fr', 'it', 'nl', 'sl',
         ],
     ],
     'surveys/survey_eoy_heartbeat.lang' => [


### PR DESCRIPTION
Not removing it for the other completed locales, because there are strings we can import in next surveys