### PR TITLE
add file mozorg/about/governance/policies/participation.lang

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -363,6 +363,11 @@ $mozillaorg_lang = [
         'priority'          => 2,
         'supported_locales' => $mozillaorg,
     ],
+    'mozorg/about/governance/policies/participation.lang' => [
+        'priority'          => 3,
+        'supported_locales' => [
+            'de', 'es-ES', 'fr', 'hi-IN', 'pt-BR', 'zh-TW',
+    ],
     'mozorg/about/history-details.lang' => [
         'flags' => [
             'opt-in' => ['all'],

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -367,6 +367,7 @@ $mozillaorg_lang = [
         'priority'          => 3,
         'supported_locales' => [
             'de', 'es-ES', 'fr', 'hi-IN', 'pt-BR', 'zh-TW',
+        ],
     ],
     'mozorg/about/history-details.lang' => [
         'flags' => [

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -364,7 +364,6 @@ $mozillaorg_lang = [
         'supported_locales' => $mozillaorg,
     ],
     'mozorg/about/governance/policies/participation.lang' => [
-        'priority'          => 3,
         'supported_locales' => [
             'de', 'es-ES', 'fr', 'hi-IN', 'pt-BR', 'zh-TW',
         ],


### PR DESCRIPTION
Per bug 1364268.

NOTE: 
- I listed es-ES as the locale, since the file lives in the corresponding repo. The file is technically in "es".  