### PR TITLE
Update file per mozilla.org PR #172

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -255,6 +255,11 @@ $mozillaorg_lang = [
         'priority'          => 1,
         'supported_locales' => $firefox_desktop_android,
     ],
+    'firefox/new/onboarding.lang' => [
+        'deadline'          => '2017-08-20',
+        'priority'          => 1,
+        'supported_locales' => $firefox_desktop_android,
+    ],
     'firefox/nightly_firstrun.lang' => [
         'flags'             => [
             'opt-in' => $firefox_locales,
@@ -288,12 +293,17 @@ $mozillaorg_lang = [
         'priority'          => 1,
         'supported_locales' => $mozillaorg,
     ],
-    'firefox/products/focus.lang' => [
+    'firefox/products/desktop.lang' => [
         'deadline'          => '2017-08-15',
         'priority'          => 1,
         'supported_locales' => $mozillaorg,
     ],
-    'firefox/products/desktop.lang' => [
+    'firefox/products/developer.lang' => [
+        'deadline'          => '2017-08-20',
+        'priority'          => 1,
+        'supported_locales' => $mozillaorg,
+    ],
+    'firefox/products/focus.lang' => [
         'deadline'          => '2017-08-15',
         'priority'          => 1,
         'supported_locales' => $mozillaorg,
@@ -313,7 +323,7 @@ $mozillaorg_lang = [
         'supported_locales' => $mozillaorg,
     ],
     'firefox/sync.lang' => [
-        'deadline'          => '2017-04-25',
+        'deadline'          => '2017-08-20',
         'priority'          => 2,
         'supported_locales' => $mozillaorg,
     ],

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -572,6 +572,16 @@ $mozillaorg_lang = [
         'priority'          => 2,
         'supported_locales' => $mozillaorg,
     ],
+    'mozorg/moss/index.lang' => [
+        'deadline'          => '2017-07-30',
+        'priority'          => 1,
+        'supported_locales' => ['hi-IN'],
+    ],
+    'mozorg/moss/mission-partners-india.lang' => [
+        'deadline'          => '2017-07-30',
+        'priority'          => 1,
+        'supported_locales' => ['hi-IN'],
+    ],
     'mozorg/newsletters.lang' => [
         'deadline'          => '2017-03-27',
         'priority'          => 2,

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -160,7 +160,9 @@ $mozillaorg_lang = [
         'supported_locales' => $firefox_locales,
     ],
     'firefox/developer.lang' => [
-        'priority'          => 2,
+        'flags'             => [
+            'obsolete' => ['all'],
+        ],
         'supported_locales' => $firefox_locales,
     ],
     'firefox/dnt.lang' => [
@@ -251,12 +253,13 @@ $mozillaorg_lang = [
         'supported_locales' => $ios_landing_page,
     ],
     'firefox/new/horizon.lang' => [
-        'deadline'          => '2017-02-20',
-        'priority'          => 1,
+        'flags'             => [
+            'obsolete' => ['all'],
+        ],
         'supported_locales' => $firefox_desktop_android,
     ],
     'firefox/new/onboarding.lang' => [
-        'deadline'          => '2017-08-20',
+        'deadline'          => '2017-08-15',
         'priority'          => 1,
         'supported_locales' => $firefox_desktop_android,
     ],
@@ -299,9 +302,8 @@ $mozillaorg_lang = [
         'supported_locales' => $mozillaorg,
     ],
     'firefox/products/developer.lang' => [
-        'deadline'          => '2017-08-20',
-        'priority'          => 1,
-        'supported_locales' => $mozillaorg,
+        'deadline'          => '2017-08-15',
+        'supported_locales' => $firefox_locales,
     ],
     'firefox/products/focus.lang' => [
         'deadline'          => '2017-08-15',
@@ -323,7 +325,7 @@ $mozillaorg_lang = [
         'supported_locales' => $mozillaorg,
     ],
     'firefox/sync.lang' => [
-        'deadline'          => '2017-08-20',
+        'deadline'          => '2017-08-15',
         'priority'          => 2,
         'supported_locales' => $mozillaorg,
     ],

--- a/app/scripts/activate_firefox_shared
+++ b/app/scripts/activate_firefox_shared
@@ -20,6 +20,7 @@ $files_to_check = [
     'firefox/hub/home.lang',
     'firefox/products/android.lang',
     'firefox/products/desktop.lang',
+    'firefox/products/developer.lang',
     'firefox/products/focus.lang',
     'firefox/products/ios.lang',
 ];


### PR DESCRIPTION
- add onboarding.lang
- add firefox/products/developer.lang
- update deadline to onboarding, developer and sync files to 8/20
- change file order under firefox/products/...

NOTE:
- to be obsolete developer.lang supports firefox locales, not mozillaorg.
- new firefox/products/developer.lang is set to be supported by mozillaorg locales. should we change?
- did not change priority for sync or new developer file.  should we? Sync 1 and dev lower?