### PR TITLE
Decode HTML entities when counting characters

### DIFF
--- a/app/classes/Langchecker/Utils.php
+++ b/app/classes/Langchecker/Utils.php
@@ -85,12 +85,14 @@ class Utils
      *
      * @param string $str A multibyte string
      *
-     * @return int The length of the string after removing all html
+     * @return int The length of the string after removing all html and decoding
+     * all entities
      */
     public static function getLength($str)
     {
         // Remove HTML tags and meta tags like {ok}
         $str = strip_tags($str);
+        $str = html_entity_decode($str);
         $str = self::cleanString($str);
 
         return mb_strlen($str, 'UTF-8');

--- a/app/classes/Langchecker/Utils.php
+++ b/app/classes/Langchecker/Utils.php
@@ -85,14 +85,16 @@ class Utils
      *
      * @param string $str A multibyte string
      *
-     * @return int The length of the string after removing all html and decoding
-     * all entities
+     * @return int The length of the string after removing HTML tags and
+     *             decoding all entities
      */
     public static function getLength($str)
     {
-        // Remove HTML tags and meta tags like {ok}
+        // Remove HTML tags
         $str = strip_tags($str);
+        // Convert HTML entities to unicode
         $str = html_entity_decode($str);
+        // Strip meta tags like "{ok}"
         $str = self::cleanString($str);
 
         return mb_strlen($str, 'UTF-8');

--- a/tests/units/Langchecker/Utils.php
+++ b/tests/units/Langchecker/Utils.php
@@ -33,6 +33,7 @@ class Utils extends atoum\test
     {
         return [
             [' test string', 'test string'],
+            [' test string', 'test string'],
             ['test string {ok} ', 'test string'],
             ['test string {OK} ', 'test string'],
             ['test string{ok} ', 'test string'],
@@ -78,8 +79,13 @@ class Utils extends atoum\test
     {
         return [
             ['Le cheval  blanc ', 16],
+            ['Le cheval&nbsp;blanc ', 15],
+            // Non breaking space at the end should not be stripped
+            ['Le cheval blanc&nbsp;', 16],
             ['<a href="">Le cheval  blanc </a>', 16],
             ['Stringa di prova {ok}', 16],
+            ['Test wrong &foobar; entity', 26],
+            ['Stringa di&quot;prova&quot; {ok}', 17],
             ['<a href="">Stringa di prova </a> {ok}', 16],
             ['મારુ ઘર પાનું બતાવો', 19],
         ];


### PR DESCRIPTION
Similar issue to bug 1461199, causing false positive on https://l10n.mozilla-community.org/langchecker/?locale=fr#snippets/2018/may2018.lang