### PR TITLE
change privacy index page locale list

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -529,7 +529,8 @@ $mozillaorg_lang = [
     ],
     'privacy/index.lang' => [
         'priority'          => 1,
-        'supported_locales' => array_diff($legal_locales, ['et']),
+        'deadline'          => '2018-07-30',
+        'supported_locales' => $mozillaorg,
     ],
     'privacy/principles.lang' => [
         'priority'          => 2,

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -6,7 +6,6 @@ $no_active_tag = [
     'main.lang',
     'mozorg/internet-health/shared.lang',
     'newsletter.lang',
-    'privacy/index.lang',
 ];
 
 $legal_locales = [


### PR DESCRIPTION
@flodolo Legal gave an ok to open up side panel to all locales. However, the Mozilla PN (main page) will be limited to the currently supported languages. I left the deadline the same as FAQ page. 