### PR TITLE
Add whatsnew_69

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -319,6 +319,13 @@ $mozillaorg_lang = [
             'de', 'en-CA', 'en-GB', 'fr',
         ],
     ],
+    'firefox/whatsnew_69.lang' => [
+        'deadline'          => '2019-08-26',
+        'priority'          => 1,
+        'supported_locales' => [
+            'de', 'en-CA', 'en-GB', 'fr',
+        ],
+    ],
     'foundation/advocacy.lang' => [
         'flags' => [
             'opt-in' => ['all'],


### PR DESCRIPTION
Lang file added in https://github.com/mozilla-l10n/www.mozilla.org/pull/326

Targeting "Tier One" locales (English, French, German) for Fx69 but we'll soon have a new evergreen default whatsnew page for all locales.