### PR TITLE
Expand whatsnew_69 to all locales

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -322,9 +322,7 @@ $mozillaorg_lang = [
     'firefox/whatsnew_69.lang' => [
         'deadline'          => '2019-08-26',
         'priority'          => 1,
-        'supported_locales' => [
-            'de', 'en-CA', 'en-GB', 'fr',
-        ],
+        'supported_locales' => $firefox_locales,
     ],
     'foundation/advocacy.lang' => [
         'flags' => [


### PR DESCRIPTION
I was mistaken previously; this should be exposed to all locales.