### PR TITLE
Add firefox/home-master.lang

### DIFF
--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -175,7 +175,7 @@ $mozillaorg_lang = [
         'supported_locales' => $mozillaorg,
     ],
     'firefox/home-master.lang' => [
-        'deadline'          => '2019-10-20',
+        'deadline'          => '2019-11-25',
         'priority'          => 1,
         'supported_locales' => $mozillaorg,
     ],

--- a/app/config/sources.inc.php
+++ b/app/config/sources.inc.php
@@ -174,6 +174,11 @@ $mozillaorg_lang = [
         'priority'          => 1,
         'supported_locales' => $mozillaorg,
     ],
+    'firefox/home-master.lang' => [
+        'deadline'          => '2019-10-20',
+        'priority'          => 1,
+        'supported_locales' => $mozillaorg,
+    ],
     'firefox/installer-help.lang' => [
         'priority'          => 2,
         'supported_locales' => $firefox_locales,


### PR DESCRIPTION
Initially just for French and German for in-house translation. We expect there may be changes to this page in the near future and we can expand to more locales once things settle down.